### PR TITLE
Fix/onsetslice reset

### DIFF
--- a/include/algorithms/public/OnsetSegmentation.hpp
+++ b/include/algorithms/public/OnsetSegmentation.hpp
@@ -33,11 +33,12 @@ public:
 
   OnsetSegmentation(index maxSize) : mFFT(maxSize), mWindowStorage(maxSize) {}
 
-  void init(index windowSize, index fftSize)
+  void init(index windowSize, index fftSize,index filterSize)
   {
     makeWindow(windowSize);
     prevFrame = ArrayXcd::Zero(fftSize / 2 + 1);
     prevPrevFrame = ArrayXcd::Zero(fftSize / 2 + 1);
+    mFilter.init(filterSize); 
     mFFT.resize(fftSize);
     mDebounceCount = 1;
     mPrevFuncVal = 0;

--- a/include/algorithms/util/MedianFilter.hpp
+++ b/include/algorithms/util/MedianFilter.hpp
@@ -29,6 +29,8 @@ public:
     mMiddle = (mFilterSize - 1) / 2;
     mUnsorted.resize(asUnsigned(mFilterSize), 0);
     mSorted.resize(asUnsigned(mFilterSize), 0);
+    std::fill(mUnsorted.begin(), mUnsorted.end(),0);
+    std::fill(mSorted.begin(), mSorted.end(),0);
     mInitialized = true;
   }
 

--- a/include/clients/common/BufferedProcess.hpp
+++ b/include/clients/common/BufferedProcess.hpp
@@ -122,7 +122,12 @@ public:
   index channelsIn() const noexcept { return mSource.channels(); }
   index channelsOut() const noexcept { return mSink.channels(); }
 
-  void reset() { mFrameTime = 0; }
+  void reset()
+  {
+    mSource.reset();
+    mSink.reset();
+    mFrameTime = 0;
+  }
 
 private:
   index               mFrameTime = 0;

--- a/include/clients/common/FluidSink.hpp
+++ b/include/clients/common/FluidSink.hpp
@@ -102,9 +102,9 @@ public:
     if (matrix.cols() != bufferSize() || matrix.rows() != channels)
     {
       matrix.resize(mChannels, bufferSize());
-      matrix.fill(0);
-      mCounter = 0;
     }
+    matrix.fill(0);
+    mCounter = 0;  
   }
 
   void setSize(index n) { mSize = n; }

--- a/include/clients/common/FluidSource.hpp
+++ b/include/clients/common/FluidSource.hpp
@@ -148,9 +148,9 @@ public:
     if (matrix.cols() != bufferSize() || matrix.rows() != channels)
     {
       matrix.resize(mChannels, bufferSize());
-      matrix.fill(0);
-      mCounter = 0;
     }
+      matrix.fill(0);
+      mCounter = 0;    
   }
 
   void setSize(index n) { mSize = n; }

--- a/include/clients/rt/OnsetSliceClient.hpp
+++ b/include/clients/rt/OnsetSliceClient.hpp
@@ -85,7 +85,9 @@ public:
                                FluidBaseClient::audioChannelsOut());
     }
     if (mParamsTracker.changed(get<kFFT>().fftSize(), get<kFFT>().winSize()))
-    { mAlgorithm.init(get<kFFT>().winSize(), get<kFFT>().fftSize()); }
+    {
+      mAlgorithm.init(get<kFFT>().winSize(), get<kFFT>().fftSize(),get<kFilterSize>());
+    }
     RealMatrix in(1, hostVecSize);
     in.row(0) = input[0];
     RealMatrix out(1, hostVecSize);
@@ -105,7 +107,7 @@ public:
   void reset()
   {
     mBufferedProcess.reset();
-    mAlgorithm.init(get<kFFT>().winSize(), get<kFFT>().fftSize());
+    mAlgorithm.init(get<kFFT>().winSize(), get<kFFT>().fftSize(),get<kFilterSize>());
   }
 
 private:


### PR DESCRIPTION
Fixes issue #3 

* `Fluid(Source|Sink)` internal state always clears
* `BufferedProcess` resets source & sink
* `OnsetSegmentation` resets filter
* `MedianFilter` clears state
* `OnsetSliceClient` passes filtersize to `OnsetSegmentation::init`