### PR TITLE
Add new built type based on RelWithDebInfo plus asserts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ endif()
 
 project (flucoma-core LANGUAGES CXX)
 
+include("${CMAKE_CURRENT_SOURCE_DIR}/script/flucoma-buildtype.cmake")
+
 include(FetchContent)
 set(HISS_PATH "" CACHE PATH "The path to a HISSTools_Library folder. Will pull from github if not set")
 set(EIGEN_PATH "" CACHE PATH "The path to an Eigen installation (>=3.3.5). Will pull from github if not set")

--- a/script/flucoma-buildtype.cmake
+++ b/script/flucoma-buildtype.cmake
@@ -1,0 +1,51 @@
+# Part of the Fluid Corpus Manipulation Project (http://www.flucoma.org/)
+# Copyright 2017-2019 University of Huddersfield.
+# Licensed under the BSD-3 License.
+# See license.md file in the project root for full license information.
+# This project has received funding from the European Research Council (ERC)
+# under the European Union’s Horizon 2020 research and innovation programme
+# (grant agreement No 725899).
+
+include_guard() 
+
+get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if(isMultiConfig)
+  if(NOT "Test" IN_LIST CMAKE_CONFIGURATION_TYPES)
+    list(APPEND CMAKE_CONFIGURATION_TYPES Test)
+  endif()
+else()
+  set(allowableBuildTypes Debug Release RelWithDebInfo Test)
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY
+               STRINGS "${allowableBuildTypes}")
+  if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "" FORCE)
+  elseif(NOT CMAKE_BUILD_TYPE IN_LIST allowableBuildTypes)
+    message(FATAL_ERROR "Invalid build type: ${CMAKE_BUILD_TYPE}")
+  endif()
+endif()
+
+if(MSVC)
+  set(ASSERTION_FLAG "/DNDEBUG")
+else()
+  set(ASSERTION_FLAG "-DNDEBUG")
+endif()
+
+# Take the RelWithDebInfo settings, but remove the NDEBUG flag, so we get assertions
+if(CMAKE_C_FLAGS_RELWITHDEBINFO)
+  string(REPLACE ${ASSERTION_FLAG} "" CMAKE_C_FLAGS_TEST ${CMAKE_C_FLAGS_RELWITHDEBINFO})
+endif()
+if(CMAKE_CXX_FLAGS_RELWITHDEBINFO)  
+string(REPLACE ${ASSERTION_FLAG} "" CMAKE_CXX_FLAGS_TEST ${CMAKE_CXX_FLAGS_RELWITHDEBINFO})
+endif()
+if(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO)
+string(REPLACE ${ASSERTION_FLAG} "" CMAKE_EXE_LINKER_FLAGS_TEST ${CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO})
+endif()
+if(CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO)
+  string(REPLACE ${ASSERTION_FLAG} "" CMAKE_SHARED_LINKER_FLAGS_TEST ${CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO})
+endif()
+if(CMAKE_STATIC_LINKER_FLAGS_RELWITHDEBINFO)
+  string(REPLACE ${ASSERTION_FLAG} "" CMAKE_STATIC_LINKER_FLAGS_TEST ${CMAKE_STATIC_LINKER_FLAGS_RELWITHDEBINFO})
+endif()
+if(CMAKE_MODULE_LINKER_FLAGS_RELWITHDEBINFO)
+  string(REPLACE ${ASSERTION_FLAG} "" CMAKE_MODULE_LINKER_FLAGS_TEST ${CMAKE_MODULE_LINKER_FLAGS_RELWITHDEBINFO})
+endif()


### PR DESCRIPTION
This is the new build type for testing. It uses the CMake built-in `RelWithDebInfo` as its basis, but removes the `NDEBUG` flag so that we still have assertions. This means that on Mac / Linux we have something like `-O2 -g`, i.e. some optimization and debug info, plus assertions. 

Before merging we just need to agree on the name. Currently it's called `Test`, and you'd select it like any other build type. E.g., if using make or ninja as your generator
```bash
cmake <stuff> -DCMAKE_BUILD_TYPE=Test
```
If you'd rather it were called something else, now is the time to say. 

Before it can be used, I need to add a line to each of the host top level CMakeLists to include the type, but it seems to work just fine. 