### PR TITLE
Add option to drop 0th MFCC

### DIFF
--- a/include/clients/rt/MFCCClient.hpp
+++ b/include/clients/rt/MFCCClient.hpp
@@ -41,7 +41,7 @@ constexpr auto MFCCParams = defineParameters(
               UpperLimit<kNBands, kMaxNCoefs>()),
     LongParam("numBands", "Number of Bands", 40, Min(2),
               FrameSizeUpperLimit<kFFT>(), LowerLimit<kNCoefs>()),
-    EnumParam("dropZero","Drop zeroth Coefficient",0, "No","Yes"),
+    EnumParam("dropZero","Drop Zeroth Coefficient",0, "No","Yes"),
     FloatParam("minFreq", "Low Frequency Bound", 20, Min(0)),
     FloatParam("maxFreq", "High Frequency Bound", 20000, Min(0)),
     LongParam<Fixed<true>>("maxNumCoeffs", "Maximum Number of Coefficients", 40,

--- a/include/clients/rt/MFCCClient.hpp
+++ b/include/clients/rt/MFCCClient.hpp
@@ -41,7 +41,7 @@ constexpr auto MFCCParams = defineParameters(
               UpperLimit<kNBands, kMaxNCoefs>()),
     LongParam("numBands", "Number of Bands", 40, Min(2),
               FrameSizeUpperLimit<kFFT>(), LowerLimit<kNCoefs>()),
-    EnumParam("dropZero","Drop Zeroth Coefficient",0, "No","Yes"),
+    LongParam("startCoeff","Output Coefficient Offset",0),
     FloatParam("minFreq", "Low Frequency Bound", 20, Min(0)),
     FloatParam("maxFreq", "High Frequency Bound", 20000, Min(0)),
     LongParam<Fixed<true>>("maxNumCoeffs", "Maximum Number of Coefficients", 40,

--- a/include/clients/rt/MFCCClient.hpp
+++ b/include/clients/rt/MFCCClient.hpp
@@ -28,6 +28,7 @@ namespace mfcc {
 enum MFCCParamIndex {
   kNCoefs,
   kNBands,
+  kDrop0,
   kMinFreq,
   kMaxFreq,
   kMaxNCoefs,
@@ -40,6 +41,7 @@ constexpr auto MFCCParams = defineParameters(
               UpperLimit<kNBands, kMaxNCoefs>()),
     LongParam("numBands", "Number of Bands", 40, Min(2),
               FrameSizeUpperLimit<kFFT>(), LowerLimit<kNCoefs>()),
+    EnumParam("dropZero","Drop zeroth Coefficient",0, "No","Yes"),
     FloatParam("minFreq", "Low Frequency Bound", 20, Min(0)),
     FloatParam("maxFreq", "High Frequency Bound", 20000, Min(0)),
     LongParam<Fixed<true>>("maxNumCoeffs", "Maximum Number of Coefficients", 40,
@@ -68,10 +70,10 @@ public:
   MFCCClient(ParamSetViewType& p)
       : mParams{p}, mSTFTBufferedProcess(get<kMaxFFTSize>(), 1, 0),
         mMelBands(get<kMaxFFTSize>(), get<kMaxFFTSize>()),
-        mDCT(get<kMaxFFTSize>(), get<kMaxNCoefs>())
+        mDCT(get<kMaxFFTSize>(), get<kMaxNCoefs>()  + 1) // + 1 for possibility of dropping 0th
   {
     mBands = FluidTensor<double, 1>(get<kNBands>());
-    mCoefficients = FluidTensor<double, 1>(get<kNCoefs>());
+    mCoefficients = FluidTensor<double, 1>(get<kNCoefs>() + get<kDrop0>() );
     audioChannelsIn(1);
     controlChannelsOut(get<kMaxNCoefs>());
     setInputLabels({"audio input"});
@@ -89,17 +91,19 @@ public:
     assert(output.size() >= asUnsigned(controlChannelsOut()) &&
            "Too few output channels");
 
-    if (mTracker.changed(get<kFFT>().frameSize(), get<kNCoefs>(),
+    bool has0 = !get<kDrop0>(); 
+
+    if (mTracker.changed(get<kFFT>().frameSize(), get<kNCoefs>() + !has0,
                          get<kNBands>(), get<kMinFreq>(), get<kMaxFreq>(),
                          sampleRate()))
     {
       mMagnitude.resize(get<kFFT>().frameSize());
       mBands.resize(get<kNBands>());
-      mCoefficients.resize(get<kNCoefs>());
+      mCoefficients.resize(get<kNCoefs>() + !has0);
       mMelBands.init(get<kMinFreq>(), get<kMaxFreq>(), get<kNBands>(),
                      get<kFFT>().frameSize(), sampleRate(),
                      get<kFFT>().winSize());
-      mDCT.init(get<kNBands>(), get<kNCoefs>());
+      mDCT.init(get<kNBands>(), get<kNCoefs>() + !has0);
     }
 
     mSTFTBufferedProcess.processInput(
@@ -108,8 +112,10 @@ public:
           mMelBands.processFrame(mMagnitude, mBands, false, false, true);
           mDCT.processFrame(mBands, mCoefficients);
         });
+    
+    index coeffOffset = !has0;
     for (index i = 0; i < get<kNCoefs>(); ++i)
-      output[asUnsigned(i)](0) = static_cast<T>(mCoefficients(i));
+      output[asUnsigned(i)](0) = static_cast<T>(mCoefficients(i + coeffOffset));
   }
 
   index latency() { return get<kFFT>().winSize(); }
@@ -119,7 +125,7 @@ public:
     mSTFTBufferedProcess.reset();
     mMagnitude.resize(get<kFFT>().frameSize());
     mBands.resize(get<kNBands>());
-    mCoefficients.resize(get<kNCoefs>());
+    mCoefficients.resize(get<kNCoefs>() + get<kDrop0>());
     mMelBands.init(get<kMinFreq>(), get<kMaxFreq>(), get<kNBands>(),
                    get<kFFT>().frameSize(), sampleRate(),
                    get<kFFT>().winSize());


### PR DESCRIPTION
Adds a new param to MFCC to drop the 0th coefficient. Will automatically show up in Max, and if we like it we can add to the SC class. 