### PR TITLE
FluidGrid: proposed dimensions output to the fitTransform method

### DIFF
--- a/include/algorithms/public/Grid.hpp
+++ b/include/algorithms/public/Grid.hpp
@@ -47,7 +47,6 @@ public:
     double   area = (xMax - xMin) * (yMax - yMin);
     double   size = static_cast<double>(N);
     double   step = sqrt(area / M);
-    index    numCols, numRows;
 
     if (area <= 0) return DataSet();
 
@@ -100,8 +99,13 @@ public:
     return result;
   }
 
+  std::pair<index, index> const getGridMax() {
+    return {numCols,numRows};
+  }
+
 private:
   Assign2D assign2D;
+  index    numCols = 0, numRows = 0;
 };
 }; // namespace algorithm
 }; // namespace fluid

--- a/include/algorithms/public/Grid.hpp
+++ b/include/algorithms/public/Grid.hpp
@@ -105,7 +105,8 @@ public:
 
 private:
   Assign2D assign2D;
-  index    numCols = 0, numRows = 0;
+index numCols{0}; 
+indes numRows{0};  
 };
 }; // namespace algorithm
 }; // namespace fluid


### PR DESCRIPTION
As discussed previously, the new size of the FluidGrid process can be a challenge to retrieve, if only because it requires another object (FluidNormalize) and dumping it in a dict and retrieving a key. 

As a weekend distraction for yours truly, I hereby propose to return the 2 maxima when the `fitTransform` method is called. This is streamlined and takes into account that the FLuidGrid object is stateless, in effect a processor.

Amended Max and SC help (and class def for the latter) also are on feature branches in their respective repos.