### PR TITLE
Fix crash due to incorrect removal of dead param listeners for shared objects

### DIFF
--- a/include/clients/nrt/FluidSharedInstanceAdaptor.hpp
+++ b/include/clients/nrt/FluidSharedInstanceAdaptor.hpp
@@ -203,8 +203,10 @@ public:
   void removeListener(void* key)
   {
     auto& listeners = mParams->listeners[N];
-    std::remove_if(listeners.begin(), listeners.end(),
-                   [&key](ListenerEntry& e) { return e.second == key; });
+    listeners.erase(
+        std::remove_if(listeners.begin(), listeners.end(),
+                       [&key](ListenerEntry& e) { return e.second == key; }),
+        listeners.end());
   }
 
 private:


### PR DESCRIPTION
A slightly embarrassing bug for shared objects that caused crashes when named-shared objects (only named-shared objects were being deleted). Unlikely to be seen often in SC, but could have caused the odd crash in Max with `dataset~/labelset~` when reinstantiating boxes. Due to there now being many more named-shared types on my branch-in-progress, I ran into this during testing. 

For future ref, one needs to remember (d'oh) that `std::remove_if` always needs to be used in conjunction with an actual `erase` operation on the container in question: `remove` only shuffles things about, it doesn't actually do the erasure. If you forget this, then one's container still has dead things littering it. 