### PR TITLE
Update CMake to use HISSTools incorporating M1 compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ FetchContent_Declare(
   HISSTools
   GIT_REPOSITORY https://github.com/AlexHarker/HISSTools_Library
   GIT_PROGRESS TRUE
-  GIT_TAG 6c09283
+  GIT_TAG 5dd8530
 )
 
 FetchContent_Declare(


### PR DESCRIPTION
fix #53 

Updates tag for HISSTools, hopefully allowing M1 builds out of the box. 