### PR TITLE
MFCCs: Ensure DCT reinits to correct size on `reset`

### DIFF
--- a/include/clients/rt/MFCCClient.hpp
+++ b/include/clients/rt/MFCCClient.hpp
@@ -131,7 +131,7 @@ public:
     mMelBands.init(get<kMinFreq>(), get<kMaxFreq>(), get<kNBands>(),
                    get<kFFT>().frameSize(), sampleRate(),
                    get<kFFT>().winSize());
-    mDCT.init(get<kNBands>(), get<kNCoefs>());
+    mDCT.init(get<kNBands>(), get<kNCoefs>() + get<kDrop0>());
   }
 
   index controlRate() { return get<kFFT>().hopSize(); }


### PR DESCRIPTION
fixes #59 

Problem was that after `reset` the DCT object has wrong size (gives a handy assertion death in debug( 