### PR TITLE
Fix eigen aliasing in `SpectralShape` and `YNINFFT`

### DIFF
--- a/include/algorithms/public/SpectralShape.hpp
+++ b/include/algorithms/public/SpectralShape.hpp
@@ -51,8 +51,9 @@ public:
       minBin = 1;
       mag(1) += mag(0);
     }
-    ArrayXd amp = usePower ? mag.square() : mag;
-    amp = amp.segment(minBin, maxBin - minBin);
+    ArrayXd amp = usePower ? mag.square() : mag; 
+    amp = amp.segment(minBin, maxBin - minBin).eval(); 
+    
     double  ampSum = amp.sum();
     ArrayXd freqs =
         ArrayXd::LinSpaced(maxBin - minBin, minBin * binHz, maxBin * binHz);

--- a/include/algorithms/public/YINFFT.hpp
+++ b/include/algorithms/public/YINFFT.hpp
@@ -61,7 +61,7 @@ public:
         maxBin = yinFlip.size() - minBin - 1;
       if (maxBin > minBin)
       {
-        yinFlip = yinFlip.segment(minBin, maxBin - minBin);
+        yinFlip = yinFlip.segment(minBin, maxBin - minBin).eval();
 
         auto vec = pd.process(yinFlip, 1, yinFlip.minCoeff());
         if (vec.size() > 0)


### PR DESCRIPTION
These changes make safe two instances where Eigen variables are aliased (`x = x.someTransformation()`) such that they resize. Eigen expects the  user to deal with such situations (https://eigen.tuxfamily.org/dox/group__TopicAliasing.html). 

The problem is that aliasing like that creates unpredictable results, because of the way that Eigen does lazy evaluation The fix I've adopted here tries to preserve the code as much as possible by using `eval` to evaluate eager-ly, using a temporary where necessary (as it probably is here). In the `SpectralShape` case, it would probably be more efficient to simply do the `segment()` on the previous line, but maybe less clear. 

Both of these were found by AddressSanitizer, who wasn't at all happy as they caused a use after free. IOW, the effects would be unpredictable as the likelihood of the memory being reused in conjunction with its read increased (so with multiple threads). 

As such, I suspect (but can't prove) that these are to blame for both `SpectralShape` and `Pitch` producing occasionally surprising results, especially on Linux and Windows. See https://discourse.flucoma.org/t/beta3-is-out-max-sc-and-pd/1041/23  and two issues on the old Bitbucket (266,267)