### PR TITLE
Remove SIMD detection magic from CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,7 +181,6 @@ if(APPLE)
 endif()
 
 #Apply any vector instruction flags
-include("${CMAKE_CURRENT_SOURCE_DIR}/script/flucoma_simdcmd.cmake")
 if(DEFINED FLUID_ARCH)
   target_compile_options(HISSTools_FFT PUBLIC ${FLUID_ARCH})
   target_compile_options(HISSTools_AudioFile PUBLIC ${FLUID_ARCH})


### PR DESCRIPTION
Caused more trouble than it solved, especially for mac UB2. 

Passing `FLUID_ARCH` from the command line should still work. This just gets rid of the hidden magic that would try and set `march` and `mtune`. If we start using CMake presets, then that would offer a less hideous way to share some useful options in a less brittle way, maybe. 