### PR TITLE
Add local + core commit SHAs to version string

### DIFF
--- a/script/flucoma_version.cmake
+++ b/script/flucoma_version.cmake
@@ -10,6 +10,19 @@ include_guard()
 
 find_package(Git REQUIRED)
 
+macro(getsha workingDir varName)
+  execute_process( 
+    COMMAND ${GIT_EXECUTABLE} log -1 --format=%h
+    WORKING_DIRECTORY ${${workingDir}}
+    OUTPUT_VARIABLE ${varName}
+    # ERROR_QUIET
+    OUTPUT_STRIP_TRAILING_WHITESPACE  
+  )
+endmacro() 
+
+getSha(CMAKE_CURRENT_LIST_DIR FLUID_CORE_SHA)
+getSha(CMAKE_CURRENT_SOURCE_DIR FLUID_VERSION_SHA)
+
 execute_process( 
   COMMAND ${GIT_EXECUTABLE} describe --abbrev=0 --always
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
@@ -18,6 +31,8 @@ execute_process(
   ERROR_QUIET
   OUTPUT_STRIP_TRAILING_WHITESPACE  
 )
+
+set(FLUID_VERSION_TAG "${FLUID_VERSION_TAG}-${FLUID_VERSION_SHA} (core: ${FLUID_CORE_SHA})")
 
 if(result)
   message(VERBOSE "Failed to get version string from Git, falling back to indexed header")

--- a/script/flucoma_version.cmake
+++ b/script/flucoma_version.cmake
@@ -32,7 +32,7 @@ execute_process(
   OUTPUT_STRIP_TRAILING_WHITESPACE  
 )
 
-set(FLUID_VERSION_TAG "${FLUID_VERSION_TAG}-${FLUID_VERSION_SHA} (core: ${FLUID_CORE_SHA})")
+set(FLUID_VERSION_TAG "${FLUID_VERSION_TAG}+sha.${FLUID_VERSION_SHA}.core.sha.${FLUID_CORE_SHA}")
 
 if(result)
   message(VERBOSE "Failed to get version string from Git, falling back to indexed header")


### PR DESCRIPTION
This uses `git log` to retrieve abbreviated SHAs for flucoma-core and the project being built, and appends them to the version string. 

I've used the [semantic versioning guidelines for including build meta data](https://semver.org/#spec-item-10)
>Build metadata MAY be denoted by appending a plus sign and a series of dot separated identifiers immediately following the patch or pre-release version. Identifiers MUST comprise only ASCII alphanumerics and hyphens [0-9A-Za-z-]. Identifiers MUST NOT be empty. Build metadata MUST be ignored when determining version precedence. Thus two versions that differ only in the build metadata, have the same precedence. Examples: 1.0.0-alpha+001, 1.0.0+20130313144700, 1.0.0-beta+exp.sha.5114f85, 1.0.0+21AF26D3—-117B344092BD.