### PR TITLE
Toggle BLAS settings for compiling on APPLE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,7 @@ endif()
 target_compile_definitions(FLUID_DECOMPOSITION INTERFACE EIGEN_MPL2_ONLY=1)
 
 if(APPLE)
-  target_compile_definitions(FLUID_DECOMPOSITION INTERFACE EIGEN_USE_BLAS=1)
+  # target_compile_definitions(FLUID_DECOMPOSITION INTERFACE EIGEN_USE_BLAS=0)
   #targeting <= 10.9, need to really emphasise that we want libc++ both to compiler and linker
   target_compile_options(HISSTools_FFT PUBLIC -stdlib=libc++)
   target_compile_options(HISSTools_AudioFile PUBLIC -stdlib=libc++)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,6 @@ endif()
 target_compile_definitions(FLUID_DECOMPOSITION INTERFACE EIGEN_MPL2_ONLY=1)
 
 if(APPLE)
-  # target_compile_definitions(FLUID_DECOMPOSITION INTERFACE EIGEN_USE_BLAS=0)
   #targeting <= 10.9, need to really emphasise that we want libc++ both to compiler and linker
   target_compile_options(HISSTools_FFT PUBLIC -stdlib=libc++)
   target_compile_options(HISSTools_AudioFile PUBLIC -stdlib=libc++)


### PR DESCRIPTION
This disables BLAS for eigen in the builds for APPLE.

In the future it should be revisited, especially with 3.4 Eigen which might solve the problem.﻿
