### PR TITLE
fix issue #23 - zeroing the output vector in the mTracker loop

### DIFF
--- a/include/clients/rt/ChromaClient.hpp
+++ b/include/clients/rt/ChromaClient.hpp
@@ -90,6 +90,7 @@ public:
     {
       mMagnitude.resize(get<kFFT>().frameSize());
       mChroma.resize(get<kNChroma>());
+      output[0].fill(0);//zero the output
       mAlgorithm.init(get<kNChroma>(), get<kFFT>().frameSize(), get<kRef>(),
                       sampleRate());
     }

--- a/include/clients/rt/ChromaClient.hpp
+++ b/include/clients/rt/ChromaClient.hpp
@@ -90,7 +90,6 @@ public:
     {
       mMagnitude.resize(get<kFFT>().frameSize());
       mChroma.resize(get<kNChroma>());
-      output[0].fill(0);//zero the output
       mAlgorithm.init(get<kNChroma>(), get<kFFT>().frameSize(), get<kRef>(),
                       sampleRate());
     }
@@ -103,6 +102,7 @@ public:
         });
 
     output[0](Slice(0,get<kNChroma>())) = mChroma; 
+    output[0](Slice(get<kNChroma>(), get<kMaxNChroma>() - get<kNChroma>())).fill(0); 
   }
 
   index latency() { return get<kFFT>().winSize(); }

--- a/include/clients/rt/MFCCClient.hpp
+++ b/include/clients/rt/MFCCClient.hpp
@@ -103,7 +103,6 @@ public:
       mMagnitude.resize(get<kFFT>().frameSize());
       mBands.resize(get<kNBands>());
       mCoefficients.resize(get<kNCoefs>() + !has0);
-      output[0].fill(0);//zero the output
       mMelBands.init(get<kMinFreq>(), get<kMaxFreq>(), get<kNBands>(),
                      get<kFFT>().frameSize(), sampleRate(),
                      get<kFFT>().winSize());
@@ -119,6 +118,7 @@ public:
   
       output[0](Slice(0, get<kNCoefs>())) =
         mCoefficients(Slice(get<kDrop0>(), get<kNCoefs>()));
+      output[0](Slice(get<kNCoefs>(), get<kMaxNCoefs>() - get<kNCoefs>())).fill(0); 
   }
 
   index latency() { return get<kFFT>().winSize(); }

--- a/include/clients/rt/MFCCClient.hpp
+++ b/include/clients/rt/MFCCClient.hpp
@@ -103,6 +103,7 @@ public:
       mMagnitude.resize(get<kFFT>().frameSize());
       mBands.resize(get<kNBands>());
       mCoefficients.resize(get<kNCoefs>() + !has0);
+      output[0].fill(0);//zero the output
       mMelBands.init(get<kMinFreq>(), get<kMaxFreq>(), get<kNBands>(),
                      get<kFFT>().frameSize(), sampleRate(),
                      get<kFFT>().winSize());

--- a/include/clients/rt/MelBandsClient.hpp
+++ b/include/clients/rt/MelBandsClient.hpp
@@ -93,7 +93,6 @@ public:
     {
       mMagnitude.resize(get<kFFT>().frameSize());
       mBands.resize(get<kNBands>());
-      output[0].fill(0);//zero the output
       mMelBands.init(get<kMinFreq>(), get<kMaxFreq>(), get<kNBands>(),
                      get<kFFT>().frameSize(), sampleRate(),
                      get<kFFT>().winSize());
@@ -108,6 +107,7 @@ public:
     // for (index i = 0; i < get<kNBands>(); ++i)
     //   output[asUnsigned(i)](0) = static_cast<T>(mBands(i));
     output[0](Slice(0,get<kNBands>())) = mBands; 
+    output[0](Slice(get<kNBands>(), get<kMaxNBands>() - get<kNBands>())).fill(0); 
   }
 
   index latency() { return get<kFFT>().winSize(); }

--- a/include/clients/rt/MelBandsClient.hpp
+++ b/include/clients/rt/MelBandsClient.hpp
@@ -93,6 +93,7 @@ public:
     {
       mMagnitude.resize(get<kFFT>().frameSize());
       mBands.resize(get<kNBands>());
+      output[0].fill(0);//zero the output
       mMelBands.init(get<kMinFreq>(), get<kMaxFreq>(), get<kNBands>(),
                      get<kFFT>().frameSize(), sampleRate(),
                      get<kFFT>().winSize());


### PR DESCRIPTION
This test code should show the difference.

```
x = {|nband=10| FluidChroma.kr(WhiteNoise.ar(0.2), nband, normalize: 1, maxNumChroma: 12).poll(1)}.play
//10 wiggles

x.set(\nband, 4)
//sample and hold instead of 0 for bands 5-10 (now fixed)

// ====

x = {|nband=10| FluidMelBands.kr(WhiteNoise.ar(0.2),nband,maxNumBands: 10).poll(1)}.play
//10 wiggles

x.set(\nband, 4)
//sample and hold instead of 0 for bands 5-10


// ====

x = {|nband=10| FluidMFCC.kr(WhiteNoise.ar(0.2),nband,maxNumCoeffs: 13).poll(1)}.play
//10 wiggles

x.set(\nband, 4)
//sample and hold instead of 0 for bands 5-10

s.reboot
```