### PR TITLE
Enhance/fewer warnings

### DIFF
--- a/include/algorithms/public/CepstrumF0.hpp
+++ b/include/algorithms/public/CepstrumF0.hpp
@@ -51,10 +51,8 @@ public:
     ArrayXd logMag = mag.max(epsilon).log();
     double  pitch = 0;
     double  confidence = 0;
-    index   minBin =
-        min<index>(lrint(sampleRate / maxFreq), asSigned(mag.size()));
-    index maxBin =
-        min<index>(lrint(sampleRate / minFreq), asSigned(mag.size()));
+    index   minBin = min<index>(lrint(sampleRate / maxFreq), mag.size());
+    index   maxBin = min<index>(lrint(sampleRate / minFreq), mag.size());
 
     mDCT.processFrame(logMag, mCepstrum);
 

--- a/include/algorithms/public/ChromaFilterBank.hpp
+++ b/include/algorithms/public/ChromaFilterBank.hpp
@@ -74,7 +74,8 @@ public:
     if(minFreq != 0 || maxFreq != -1){
         maxFreq = (maxFreq == -1) ? (mSampleRate / 2) : min(maxFreq, mSampleRate / 2);
         double  binHz = mSampleRate / ((mNBins - 1) * 2.);
-        index   minBin = minFreq == 0? 0 : ceil(minFreq / binHz);
+        index   minBin =
+            minFreq == 0 ? 0 : static_cast<index>(ceil(minFreq / binHz));
         index   maxBin =
             min(static_cast<index>(floorl(maxFreq / binHz)), (mNBins - 1));
         frame.segment(0, minBin).setZero();

--- a/include/algorithms/public/Grid.hpp
+++ b/include/algorithms/public/Grid.hpp
@@ -65,17 +65,17 @@ public:
     ArrayXd colPos, rowPos;
     if (extent > 0 && axis == 1)
     {
-      rowPos = ArrayXi::LinSpaced(M, 0, M - 1)
+      rowPos = ArrayXidx::LinSpaced(M, 0, M - 1)
                    .unaryExpr([&](const index x) { return x % numRows; })
                    .cast<double>();
-      colPos = (ArrayXi::LinSpaced(M, 0, M - 1) / numRows).cast<double>();
+      colPos = (ArrayXidx::LinSpaced(M, 0, M - 1) / numRows).cast<double>();
     }
     else
     {
-      colPos = ArrayXi::LinSpaced(M, 0, M - 1)
+      colPos = ArrayXidx::LinSpaced(M, 0, M - 1)
                    .unaryExpr([&](const index x) { return x % numCols; })
                    .cast<double>();
-      rowPos = (ArrayXi::LinSpaced(M, 0, M - 1) / numCols).cast<double>();
+      rowPos = (ArrayXidx::LinSpaced(M, 0, M - 1) / numCols).cast<double>();
     }
 
     ArrayXd  xPos = xMin + (colPos / (numCols - 1)) * (xMax - xMin);
@@ -83,7 +83,7 @@ public:
     ArrayXXd grid(M, 2);
     grid << xPos, yPos;
     ArrayXXd cost = algorithm::DistanceMatrix<ArrayXXd>(data, grid, 1);
-    ArrayXi  assignment(N);
+    ArrayXidx  assignment(N);
     bool     outcome = assign2D.process(cost, assignment);
     if (!outcome) return DataSet();
 

--- a/include/algorithms/public/Grid.hpp
+++ b/include/algorithms/public/Grid.hpp
@@ -103,5 +103,5 @@ public:
 private:
   Assign2D assign2D;
 };
-}; // namespace algorithm
-}; // namespace fluid
+}// namespace algorithm
+}// namespace fluid

--- a/include/algorithms/public/MDS.hpp
+++ b/include/algorithms/public/MDS.hpp
@@ -52,5 +52,5 @@ public:
     out = asFluid(result);
   }
 };
-}; // namespace algorithm
-}; // namespace fluid
+}// namespace algorithm
+}// namespace fluid

--- a/include/algorithms/public/NMFCross.hpp
+++ b/include/algorithms/public/NMFCross.hpp
@@ -87,10 +87,10 @@ private:
     using namespace std;
     vector<double> stdVec(vec.data(), vec.data() + vec.size());
     sort(stdVec.begin(), stdVec.end());
-    vector<index> idx(vec.size());
+    vector<index> idx(asUnsigned(vec.size()));
     iota(idx.begin(), idx.end(), 0);
     sort(idx.begin(), idx.end(),
-         [&vec](size_t i1, size_t i2) { return vec[i1] > vec[i2]; });
+         [&vec](index i1, index i2) { return vec[i1] > vec[i2]; });
     auto result = std::vector<index>(idx.begin(), idx.begin() + c);
     return result;
   }

--- a/include/algorithms/public/NMFMorph.hpp
+++ b/include/algorithms/public/NMFMorph.hpp
@@ -69,8 +69,8 @@ public:
     mRTPGHI.init(fftSize);
 
     index rank = mW1.cols();
-    mOT = std::vector<OptimalTransport>(rank);
-    for (index i = 0; i < rank; i++) { mOT[i].init(mW1.col(i), mW2.col(i)); }
+    mOT = std::vector<OptimalTransport>(asUnsigned(rank));
+    for (index i = 0; i < rank; i++) { mOT[asUnsigned(i)].init(mW1.col(i), mW2.col(i)); }
     mPos = 0;
   }
 
@@ -82,7 +82,7 @@ public:
     for (int i = 0; i < W.cols(); i++)
     {
       ArrayXd out = ArrayXd::Zero(mW2.rows());
-      mOT[i].interpolate(interpolation, out);
+      mOT[asUnsigned(i)].interpolate(interpolation, out);
       W.col(i) = out;
     }
 

--- a/include/algorithms/public/Normalization.hpp
+++ b/include/algorithms/public/Normalization.hpp
@@ -135,5 +135,5 @@ public:
   ArrayXd mDataRange;
   bool    mInitialized{false};
 };
-}; // namespace algorithm
-}; // namespace fluid
+}// namespace algorithm
+}// namespace fluid

--- a/include/algorithms/public/PCA.hpp
+++ b/include/algorithms/public/PCA.hpp
@@ -91,5 +91,5 @@ public:
   VectorXd mMean;
   bool     mInitialized{false};
 };
-}; // namespace algorithm
-}; // namespace fluid
+}// namespace algorithm
+}// namespace fluid

--- a/include/algorithms/public/RobustScaling.hpp
+++ b/include/algorithms/public/RobustScaling.hpp
@@ -157,5 +157,5 @@ public:
   ArrayXd mRange;
   bool    mInitialized{false};
 };
-}; // namespace algorithm
-}; // namespace fluid
+}// namespace algorithm
+}// namespace fluid

--- a/include/algorithms/public/SpectralShape.hpp
+++ b/include/algorithms/public/SpectralShape.hpp
@@ -37,7 +37,7 @@ public:
     ArrayXd mag = in.max(epsilon);
     index   nBins = mag.size();
     double  binHz = sampleRate / ((nBins - 1) * 2.);
-    index   minBin = ceil(minFreq / binHz);
+    index   minBin = static_cast<index>(ceil(minFreq / binHz));
     index   maxBin =
         min(static_cast<index>(floorl(maxFreq / binHz)), (nBins - 1));
     if (maxBin <= minBin)

--- a/include/algorithms/public/Standardization.hpp
+++ b/include/algorithms/public/Standardization.hpp
@@ -102,5 +102,5 @@ public:
   ArrayXd mStd;
   bool    mInitialized{false};
 };
-}; // namespace algorithm
-}; // namespace fluid
+}// namespace algorithm
+}// namespace fluid

--- a/include/algorithms/public/UMAP.hpp
+++ b/include/algorithms/public/UMAP.hpp
@@ -409,5 +409,5 @@ private:
   ArrayXXd mEmbedding;
   bool     mInitialized{false};
 };
-}; // namespace algorithm
-}; // namespace fluid
+}// namespace algorithm
+}// namespace fluid

--- a/include/algorithms/util/Assign2D.hpp
+++ b/include/algorithms/util/Assign2D.hpp
@@ -31,8 +31,9 @@ public:
   using ArrayXXd = Eigen::ArrayXXd;
   using ArrayXi = Eigen::ArrayXi;
   static const index UNASSIGNED = -1;
+
   bool process(Eigen::Ref<const Eigen::ArrayXXd> costMatrix,
-               Eigen::Ref<Eigen::ArrayXi>        result)
+               Eigen::Ref<ArrayXidx>             result)
   {
     using namespace std;
     using namespace Eigen;
@@ -45,8 +46,8 @@ public:
     }
     else mTransposed = false;
 
-    mRow2Col = ArrayXi::Constant(mCost.rows(), UNASSIGNED);
-    mCol2Row = ArrayXi::Constant(mCost.cols(), UNASSIGNED);
+    mRow2Col = ArrayXidx::Constant(mCost.rows(), UNASSIGNED);
+    mCol2Row = ArrayXidx::Constant(mCost.cols(), UNASSIGNED);
     mV = ArrayXd::Zero(mCost.rows());
     mU = ArrayXd::Zero(mCost.cols());
     for (index c = 0; c < mCost.cols(); c++){
@@ -69,10 +70,10 @@ public:
 
   index shortestPath(index c){
     using namespace std;
-    mPred = ArrayXi::Zero(mCost.rows());
-    ArrayXi scannedCols = ArrayXi::Zero(mCost.cols());
-    ArrayXi scannedRows = ArrayXi::Zero(mCost.rows());
-    vector<int> row2Scan(mCost.rows());
+    mPred = ArrayXidx::Zero(mCost.rows());
+    ArrayXidx scannedCols = ArrayXidx::Zero(mCost.cols());
+    ArrayXidx scannedRows = ArrayXidx::Zero(mCost.rows());
+    vector<index> row2Scan(asUnsigned(mCost.rows()));
     iota(row2Scan.begin(), row2Scan.end(), 0);
     index nRows2Scan = mCost.rows();
     index sink = UNASSIGNED;
@@ -85,7 +86,7 @@ public:
       scannedCols(currentCol) = 1;
       minVal = infinity;
       for(index r = 0; r < nRows2Scan; r++){
-        currentRow = row2Scan[r];
+        currentRow = row2Scan[asUnsigned(r)];
         reducedCost = delta
                     + mCost(currentRow, currentCol)
                     - mU(currentCol) - mV(currentRow);
@@ -99,7 +100,7 @@ public:
         }
       }
       if(isinf(minVal)) return UNASSIGNED;
-      closestRow = row2Scan[currentClosestRow];
+      closestRow = row2Scan[asUnsigned(currentClosestRow)];
       scannedRows(closestRow) = 1;
       nRows2Scan--;
       row2Scan.erase(row2Scan.begin() + currentClosestRow);
@@ -123,11 +124,11 @@ public:
 }
 private:
   ArrayXXd mCost;
-  ArrayXi  mRow2Col;
-  ArrayXi  mCol2Row;
+  ArrayXidx  mRow2Col;
+  ArrayXidx  mCol2Row;
   ArrayXd  mU;
   ArrayXd  mV;
-  ArrayXi mPred;
+  ArrayXidx mPred;
   bool mTransposed{false};
 };
 } // namespace algorithm

--- a/include/algorithms/util/FluidEigenMappings.hpp
+++ b/include/algorithms/util/FluidEigenMappings.hpp
@@ -64,7 +64,7 @@ auto asFluid(const PlainObjectBase<Derived>& a)
 
   if (N == 2)
   {
-    if (a.Options == ColMajor)
+    if (static_cast<int>(a.Options) == static_cast<int>(ColMajor))
     {
       // Respect the colmajorness of an eigen type
       auto slice = FluidTensorSlice<N>(0, {a.cols(), a.rows()});

--- a/include/algorithms/util/OptimalTransport.hpp
+++ b/include/algorithms/util/OptimalTransport.hpp
@@ -82,7 +82,7 @@ public:
       masses.emplace_back(SpectralMass{start, center, end, mass});
       nextValley++;
     }
-    if (nextValley < valleys.size() - 1)
+    if (nextValley < asSigned(valleys.size() - 1))
     {
       index lastStart = valleys[asUnsigned(nextValley)];
       index lastSize = magnitude.size() - 1 - lastStart;

--- a/include/algorithms/util/OutlierDetection.hpp
+++ b/include/algorithms/util/OutlierDetection.hpp
@@ -30,9 +30,9 @@ public:
                double k)
   {
     index   length = input.size();
-    ArrayXi perm = ArrayXi::LinSpaced(length, 0, length - 1);
+    ArrayXidx perm = ArrayXidx::LinSpaced(length, 0, length - 1);
     std::sort(perm.data(), perm.data() + length,
-              [&](size_t i, size_t j) { return input(i) < input(j); });
+              [&](index i, index j) { return input(i) < input(j); });
     index  q1 = lrint(0.25 * (length - 1));
     index  q3 = lrint(0.75 * (length - 1));
     double margin = k * (input(perm(q3)) - input(perm(q1)));

--- a/include/algorithms/util/RTPGHI.hpp
+++ b/include/algorithms/util/RTPGHI.hpp
@@ -65,7 +65,7 @@ public:
     double absTol =
         log(tolerance) + max(currentLogMag.maxCoeff(), prevLogMag.maxCoeff());
     ArrayXd todo = (currentLogMag > absTol).cast<double>();
-    index   numTodo = todo.sum();
+    index   numTodo = static_cast<index>(todo.sum());
     ArrayXd phaseEst = pi + ArrayXd::Random(mBins) * pi;
 
     vector<pair<double, index>> heap;

--- a/include/algorithms/util/SpectralEmbedding.hpp
+++ b/include/algorithms/util/SpectralEmbedding.hpp
@@ -28,7 +28,7 @@ public:
     SparseMatrixXd I = SparseMatrixXd(D.rows(), D.cols());
     I.setIdentity();
     SparseMatrixXd           L = I - (D * (graph * D));
-    int                      k = dims + 1;
+    int                      k = static_cast<int>(dims + 1);
     index                    ncv = max(2 * k + 1, int(round(sqrt(L.rows()))));
     VectorXd                 initV = VectorXd::Ones(L.rows());
     SparseSymMatProd<double> op(L);

--- a/include/algorithms/util/SpectralEmbedding.hpp
+++ b/include/algorithms/util/SpectralEmbedding.hpp
@@ -51,5 +51,5 @@ private:
   Eigen::MatrixXd mEigenVectors;
   Eigen::MatrixXd mEigenValues;
 };
-}; // namespace algorithm
-}; // namespace fluid
+}// namespace algorithm
+}// namespace fluid

--- a/include/algorithms/util/SpectralEmbedding.hpp
+++ b/include/algorithms/util/SpectralEmbedding.hpp
@@ -35,7 +35,7 @@ public:
     SymEigsSolver<double, SMALLEST_MAGN, SparseSymMatProd<double>> eig(&op, k,
                                                                        ncv);
     eig.init(initV.data());
-    auto nConverged = eig.compute(
+    /*auto nConverged = */eig.compute(
         D.cols(), 1e-4, SMALLEST_MAGN); // TODO: failback if not converging
     mEigenVectors = eig.eigenvectors();
     mEigenValues = eig.eigenvalues();

--- a/include/algorithms/util/WeightedStats.hpp
+++ b/include/algorithms/util/WeightedStats.hpp
@@ -38,9 +38,9 @@ public:
     double kurtosis =
         (weights * ((input - mean) / (stdev == 0 ? 1 : stdev)).pow(4)).sum();
     ArrayXd sorted = input;
-    ArrayXi perm = ArrayXi::LinSpaced(length, 0, length - 1);
+    ArrayXidx perm = ArrayXidx::LinSpaced(length, 0, length - 1);
     std::sort(perm.data(), perm.data() + length,
-              [&](size_t i, size_t j) { return input(i) < input(j); });
+              [&](index i, index j) { return input(i) < input(j); });
     index  level = 0;
     double lowVal{input(perm(0))};
     double midVal{input(perm(lrint(length - 1) / 2))};

--- a/include/clients/common/FluidNRTClientWrapper.hpp
+++ b/include/clients/common/FluidNRTClientWrapper.hpp
@@ -394,10 +394,7 @@ public:
     constexpr size_t WinOffset = 2;
     constexpr size_t HopOffset = 3;
 
-    auto winSizeDescriptor =
-        mParams.get().template descriptorAt<ParamOffset + WinOffset>();
-
-    assert(winSizeDescriptor.name == "windowSize");
+    assert((mParams.get().template descriptorAt<ParamOffset + WinOffset>()).name == "windowSize");
 
     index winSize = get<ParamOffset + WinOffset>();
     index hopSize = get<ParamOffset + HopOffset>();

--- a/include/clients/nrt/BufFlattenClient.hpp
+++ b/include/clients/nrt/BufFlattenClient.hpp
@@ -67,7 +67,6 @@ public:
 
     auto  srcptr = get<kSource>().get();
     index startFrame = get<kOffset>();
-    index axis = get<kAxis>();
     index numFrames = get<kNumFrames>();
     index numChans = get<kNumChans>();
     index startChan = get<kStartChan>();

--- a/include/clients/nrt/BufSTFTClient.hpp
+++ b/include/clients/nrt/BufSTFTClient.hpp
@@ -120,11 +120,13 @@ private:
     index  padding = FFTParams::padding(get<kFFT>(), get<kPadding>());
     double totalPadding = padding << 1;
 
-    index paddedLength = numFrames + totalPadding;
+    index paddedLength = static_cast<index>(numFrames + totalPadding);
     if (get<kPadding>() == 2)
-      paddedLength = (std::ceil(double(paddedLength) / hopSize) * hopSize);
+      paddedLength = static_cast<index>(
+          std::ceil(double(paddedLength) / hopSize) * hopSize);
 
-    index numHops = 1 + std::floor((paddedLength - winSize) / hopSize);
+    index numHops =
+        static_cast<index>(1 + std::floor((paddedLength - winSize) / hopSize));
 
     index numBins = (fftSize >> 1) + 1;
 

--- a/include/clients/nrt/CommonResults.hpp
+++ b/include/clients/nrt/CommonResults.hpp
@@ -46,12 +46,13 @@ template <typename T>
 MessageResult<T> Error(std::string msg)
 {
   return MessageResult<T>{Result::Status::kError, msg};
-};
+}
 
 MessageResult<void> Error(std::string msg)
 {
   return MessageResult<void>{Result::Status::kError, msg};
-};
+}
+
 MessageResult<void> OK() { return MessageResult<void>{Result::Status::kOk}; }
 } // namespace client
 } // namespace fluid

--- a/include/clients/nrt/KDTreeClient.hpp
+++ b/include/clients/nrt/KDTreeClient.hpp
@@ -174,7 +174,7 @@ public:
 
   template <typename T>
   void process(std::vector<FluidTensorView<T, 1>>& input,
-               std::vector<FluidTensorView<T, 1>>& output, FluidContext& c)
+               std::vector<FluidTensorView<T, 1>>& output, FluidContext&)
   {
     output[0] = input[0];
 

--- a/include/clients/nrt/NMFCrossClient.hpp
+++ b/include/clients/nrt/NMFCrossClient.hpp
@@ -98,11 +98,11 @@ public:
 
     index srcFrames = source.numFrames();
     index tgtFrames = target.numFrames();
-    index srcWindows =
-        std::floor((srcFrames + fftParams.hopSize()) / fftParams.hopSize());
+    index srcWindows = static_cast<index>(
+        std::floor((srcFrames + fftParams.hopSize()) / fftParams.hopSize()));
     index nBins = fftParams.frameSize();
-    index tgtWindows =
-        std::floor((tgtFrames + fftParams.hopSize()) / fftParams.hopSize());
+    index tgtWindows = static_cast<index>(
+        std::floor((tgtFrames + fftParams.hopSize()) / fftParams.hopSize()));
 
     if (srcFrames <= 0) return {Result::Status::kError, "Empty source buffer"};
 

--- a/include/clients/rt/PitchClient.hpp
+++ b/include/clients/rt/PitchClient.hpp
@@ -119,10 +119,10 @@ public:
     // pitch
     if(get<kUnit>() == 1){
       output[0](0) = mDescriptors(0) == 0? -999:
-      69 + (12 * log2(mDescriptors(0) / 440.0));
+      static_cast<T>(69 + (12 * log2(mDescriptors(0) / 440.0)));
     }
     else {
-      output[0](0) = mDescriptors(0);
+      output[0](0) = static_cast<T>(mDescriptors(0));
     }
     // pitch confidence
     output[0](1) = static_cast<T>(mDescriptors(1));

--- a/include/data/TensorTypes.hpp
+++ b/include/data/TensorTypes.hpp
@@ -10,6 +10,7 @@ under the European Union’s Horizon 2020 research and innovation programme
 #pragma once
 
 #include "FluidTensor.hpp"
+#include <Eigen/Core> 
 #include <complex>
 
 namespace fluid {
@@ -24,4 +25,6 @@ using ComplexMatrixView = FluidTensorView<std::complex<double>, 2>;
 using RealVectorView = FluidTensorView<double, 1>;
 using ComplexVectorView = FluidTensorView<std::complex<double>, 1>;
 
+using ArrayXXidx = Eigen::Array<fluid::index, Eigen::Dynamic, Eigen::Dynamic>; 
+using ArrayXidx = Eigen::Array<fluid::index, Eigen::Dynamic, 1>; 
 } // namespace fluid


### PR DESCRIPTION
Reduce the warning count on clang builds (I'm sure there's more lurking from GCC and MSVC). Commits are separated by the type of warning, except that for handling integer conversion warnings in algorithms, 42d24fa7e219a1eea28d45934564134f94422d66 is done separately from the simpler cases because it introduces a new Eigen alias and so might be more controversial. 

In a couple of cases using `Eigen::ArrayXi` was the cause of lots of conversion warnings, and tidying them up with `static_cast` was going to be a mess. The intent of the code seems to be to have an Eigen array of the same integral type that is used for all other indexing, so I introduce a new alias `fluid::ArrayXidx` which is an Eigen array of `fluid::index`. 