### PR TITLE
Amend upper frequency limit of mel bands in NoveltySlice to 20kHz

### DIFF
--- a/include/clients/rt/NoveltySliceClient.hpp
+++ b/include/clients/rt/NoveltySliceClient.hpp
@@ -111,7 +111,7 @@ public:
     else if (feature == 1)
     {
       mBands.resize(40);
-      mMelBands.init(20, 2000, 40, get<kFFT>().frameSize(), sampleRate(),
+      mMelBands.init(20, 20e3, 40, get<kFFT>().frameSize(), sampleRate(),
                      get<kFFT>().winSize());
       mDCT.init(40, 13);
       nDims = 13;


### PR DESCRIPTION
closes #86 

This is a trivial change, fixing what seems to be a typo in the `NoveltySliceClient`. However, existing example code and stuff you might all be working on that uses novelty slicing with MFCCs will possibly be affected and need re-tuning. Hence a PR rather than just changing it. 

The expected results on the test will certainly need to change. 