### PR TITLE
BufAudioTransport now has A-B based arguments

### DIFF
--- a/include/clients/common/FluidNRTClientWrapper.hpp
+++ b/include/clients/common/FluidNRTClientWrapper.hpp
@@ -43,14 +43,14 @@ template <typename B>
 auto constexpr makeWrapperInputs(B b1, B b2)
 {
   return defineParameters(
-      std::forward<B>(b1), LongParam("startFrame", "Source Offset", 0, Min(0)),
-      LongParam("numFrames", "Number of Frames", -1),
-      LongParam("startChan", "Start Channel", 0, Min(0)),
-      LongParam("numChans", "Number of Channels", -1), std::forward<B>(b2),
-      LongParam("startFrameB", "Source Offset B", 0, Min(0)),
-      LongParam("numFramesB", "Number of Frames B", -1),
-      LongParam("startChanB", "Start Channel B", 0, Min(0)),
-      LongParam("numChansB", "Number of Channels B", -1));
+      std::forward<B>(b1), LongParam("startFrameA", "Source A Offset", 0, Min(0)),
+      LongParam("numFramesA", "Source A Number of Frames", -1),
+      LongParam("startChanA", "Source A Start Channel", 0, Min(0)),
+      LongParam("numChansA", "Source A Number of Channels", -1), std::forward<B>(b2),
+      LongParam("startFrameB", "Source B Offset", 0, Min(0)),
+      LongParam("numFramesB", "Source B Number of Frames", -1),
+      LongParam("startChanB", "Source B Start Channel", 0, Min(0)),
+      LongParam("numChansB", "Source B Number of Channels", -1));
 }
 
 template <typename... B>

--- a/include/clients/rt/AudioTransportClient.hpp
+++ b/include/clients/rt/AudioTransportClient.hpp
@@ -104,8 +104,8 @@ using RTAudioTransportClient =
 
 auto constexpr NRTAudioTransportParams =
     makeNRTParams<audiotransport::AudioTransportClient>(
-        InputBufferParam("source1", "Source Buffer 1"),
-        InputBufferParam("source2", "Source Buffer 2"),
+        InputBufferParam("sourceA", "Source Buffer A"),
+        InputBufferParam("sourceB", "Source Buffer B"),
         BufferParam("destination", "Destination Buffer"));
 
 using NRTAudioTransport = NRTStreamAdaptor<audiotransport::AudioTransportClient,


### PR DESCRIPTION
Because this affects (at least) 3 of our repos, I thought it would be good to get everyone's eyes over it!

This converts BufAudioTransport's arguments to an A/B based system for the two input buffers. I tested this and it all seems to be working great.

In response to: https://github.com/flucoma/flucoma-docs/issues/66
Parallel to:
* https://github.com/flucoma/flucoma-sc/pull/62
* https://github.com/flucoma/flucoma-docs/pull/69

<img width="514" alt="Screenshot 2022-02-07 at 15 19 29" src="https://user-images.githubusercontent.com/1531144/152865155-8eff2d4c-7898-4f6b-869d-01eccc5a701d.png">