### PR TITLE
[Version] Bump version of core to beta5

### DIFF
--- a/FlucomaVersion.cmake
+++ b/FlucomaVersion.cmake
@@ -13,7 +13,7 @@ find_package(Git REQUIRED)
 set(flucoma_VERSION_MAJOR 1)
 set(flucoma_VERSION_MINOR 0)
 set(flucoma_VERSION_PATCH 0)
-set(flucoma_VERSION_SUFFIX TB2.beta4)
+set(flucoma_VERSION_SUFFIX TB2.beta5)
 
 function(make_flucoma_version_string output_variable)
   set(${output_variable}    


### PR DESCRIPTION
This bumps the version of the toolkit to beta5 which will be followed by a merge of dev -> main.﻿
