### PR TITLE
Enhance `ParameterSet`

### DIFF
--- a/include/clients/common/ParameterSet.hpp
+++ b/include/clients/common/ParameterSet.hpp
@@ -53,6 +53,14 @@ class ParameterDescriptorSet<std::index_sequence<Os...>, std::tuple<Ts...>>
         std::integral_constant<bool,
                                !(std::is_base_of<impl::Relational, T>::value)>;
   };
+  
+  template <typename T>
+  struct IsParamType
+  {
+    template <typename U>
+    using apply = std::is_same<T, typename std::tuple_element<0, U>::type>;
+  };
+
 
   template <typename T>
   using DefaultValue = decltype(std::declval<T>().defaultValue);
@@ -87,11 +95,14 @@ public:
       typename impl::FilterTupleIndices<IsNonRelational, T, List>::type;
 
 
+  template<typename T>
+  constexpr static index NumOfType = impl::FilterTupleIndices<IsParamType<T>, DescriptorType, IndexList>::type::size();
+
   template <typename T>
-  index NumOf() const
+  constexpr index NumOf() const
   {
     return
-        typename impl::FilterTupleIndices<T, DescriptorType, IndexList>::size();
+        typename impl::FilterTupleIndices<T, DescriptorType, IndexList>::type::size();
   }
 
   static constexpr index NumFixedParams = FixedIndexList::size();
@@ -302,6 +313,22 @@ public:
         IsParamType<T>, std::decay_t<DescriptorType>, IndexList>::type;
     forEachParamImpl<Func>(Is{}, std::forward<Args>(args)...);
   }
+  
+  //lambda version
+  template <typename T, class Func,
+            typename... Args>
+  void forEachParamType(Func&& f, Args&&... args)
+  {
+    using Is = typename impl::FilterTupleIndices<
+        IsParamType<T>, std::decay_t<DescriptorType>, IndexList>::type;
+    
+    ForThese(mParams,std::forward<Func>(f),Is{},std::forward<Args>(args)...);
+        
+    // /forEachParamImpl<Func>(Is{}, std::forward<Args>(args)...);
+  }
+  
+  
+  
 
   void reset() { resetImpl(IndexList()); }
 
@@ -362,8 +389,18 @@ public:
   }
 
   ValueTuple toTuple() { return {mParams}; }
+  
+  template<typename T>
+  static constexpr index NumOfType()
+  {
+    return
+        typename impl::FilterTupleIndices<IsParamType<T>, DescriptorType, IndexList>::size();
+
+  }
+
 
 private:
+
   template <typename T>
   struct IsParamType
   {

--- a/include/clients/nrt/BufStatsClient.hpp
+++ b/include/clients/nrt/BufStatsClient.hpp
@@ -51,7 +51,7 @@ constexpr auto BufStatsParams = defineParameters(
     FloatParam("high", "High Percentile", 100, Min(0), Max(100),
                LowerLimit<kMiddle>()),
     FloatParam("outliersCutoff", "Outliers Cutoff", -1, Min(-1)),
-    BufferParam("weights", "Weights Buffer"));
+    InputBufferParam("weights", "Weights Buffer"));
 
 class BufferStatsClient : public FluidBaseClient,
                           public OfflineIn,

--- a/include/clients/nrt/FluidSharedInstanceAdaptor.hpp
+++ b/include/clients/nrt/FluidSharedInstanceAdaptor.hpp
@@ -173,6 +173,15 @@ public:
         std::forward<Args>(args)...);
   }
 
+
+  //lambda version
+  template <typename T, class Func,
+            typename... Args>
+  void forEachParamType(Func&& f, Args&&... args)
+  {
+    mParams->params.template forEachParamType<T>(std::forward<Func>(f),std::forward<Args>(args)...);
+  }
+  
   void reset() { mParams->params.reset(); }
 
   template <size_t N>
@@ -196,7 +205,13 @@ public:
   {
     return mParams->params.template subset<offset>();
   }
-
+  
+  template <size_t N>
+  auto descriptorAt()
+  {
+    return mParams->params.template descriptor<N>();
+  }
+  
   template <typename Tuple>
   void fromTuple(Tuple vals)
   {

--- a/include/data/FluidMeta.hpp
+++ b/include/data/FluidMeta.hpp
@@ -164,6 +164,15 @@ void ForEach(Tuple&& tuple, F&& f, Args&&... args)
               std::make_index_sequence<N>{}, std::forward<Args>(args)...);
 }
 
+template <typename Tuple, typename F, typename Indices, typename... Args>
+void ForThese(Tuple&& tuple, F&& f, Indices idx, Args&&... args)
+{
+  constexpr size_t N = std::tuple_size<std::remove_reference_t<Tuple>>::value;
+  ForEachIndexImpl(std::forward<Tuple>(tuple), std::forward<F>(f), idx,
+                   std::forward<Args>(args)...);
+}
+
+
 namespace impl {
 
 template <std::size_t... Is>


### PR DESCRIPTION
Small additions to parameter set that improve applying functions to subsets of parameters by type, and for finding out how many parameters of a given type there are. 

This is in support of POC work for buffer processing objects being able to supply default output buffers, and to make lower-boilerplate chaining of processes easier (initially in Max, but might be applicable to other hosts) 