### PR TITLE
ParameterDescriptors: make more composable by adding insert function

### DIFF
--- a/include/clients/common/ParameterSet.hpp
+++ b/include/clients/common/ParameterSet.hpp
@@ -100,7 +100,7 @@ public:
   constexpr ParameterDescriptorSet(const Ts&&... ts)
       : mDescriptors{std::make_tuple(ts...)}
   {}
-  constexpr ParameterDescriptorSet(const std::tuple<Ts...>&& t)
+  constexpr ParameterDescriptorSet(const std::tuple<Ts...>& t)
       : mDescriptors{t}
   {}
 
@@ -622,6 +622,19 @@ constexpr ParamDescTypeFor<Args...> defineParameters(Args&&... args)
 {
   return {std::forward<Args>(args)...};
 }
+
+template<typename...Ts>
+constexpr ParamDescTypeFor<Ts...> defineParametersFromTuple(const std::tuple<Ts...>& t)
+{
+  return {t};
+}
+
+template <size_t N,typename P, typename... Args>
+constexpr auto insertParameterAfter(ParamDescTypeFor<Args...> d,const P&& param)
+{
+  return defineParametersFromTuple(impl::tupleInsertAfter<N>(d.descriptors(),param));
+}
+
 
 auto constexpr NoParameters = defineParameters();
 

--- a/include/clients/common/TupleUtilities.hpp
+++ b/include/clients/common/TupleUtilities.hpp
@@ -143,6 +143,50 @@ constexpr size_t zeroAll()
 template <typename... Ts>
 using zeroSequenceFor = std::index_sequence<zeroAll<Ts>()...>;
 
+
+template<typename T>
+constexpr std::tuple<T> Include(T& t, std::true_type)
+{
+  return std::make_tuple(t);
+}
+
+template<typename T>
+constexpr std::tuple<> Include(T&, std::false_type)
+{
+  return std::make_tuple();
+}
+
+template<size_t N,typename...Ts,size_t...Is>
+constexpr auto tupleHead_impl(const std::tuple<Ts...>& t,std::index_sequence<Is...>)
+{
+  return std::tuple_cat(Include(std::get<Is>(t),std::integral_constant<bool, (Is < N)>{})...);
+}
+
+template<size_t N,typename...Ts>
+constexpr auto tupleHead(const std::tuple<Ts...>& t)
+{
+  return tupleHead_impl<N>(t,std::make_index_sequence<sizeof...(Ts)>{});
+}
+
+template<size_t N,typename...Ts,size_t...Is>
+constexpr auto tupleTail_impl(const std::tuple<Ts...>& t,std::index_sequence<Is...>)
+{
+  return std::tuple_cat(Include(std::get<Is>(t),std::integral_constant<bool,(Is >= N)>{})...);
+}
+
+template<size_t N,typename...Ts>
+constexpr auto tupleTail(const std::tuple<Ts...>& t)
+{
+  return tupleTail_impl<N>(t,std::make_index_sequence<sizeof...(Ts)>{});
+}
+
+template<size_t N,typename T, typename...Ts>
+constexpr auto tupleInsertAfter(const std::tuple<Ts...>& t, T&& x)
+{
+  return std::tuple_cat(tupleHead<N>(t), std::make_tuple(std::forward<T>(x)),
+                        tupleTail<N>(t));
+}
+
 } // namespace impl
 } // namespace client
 } // namespace fluid


### PR DESCRIPTION
Apropos #99, @g-roma wanted a facility to insert a parameter declaration into an existing set

e.g.
```c++ 
constexpr auto SKMeansParams = insertParameterAfter<1>(
    KMeansParams,
    FloatParam("encodingThreshold", "Encoding Threshold", 0.25, Min(0), Max(1))
); 
```

to save writing
```c++
constexpr auto SKMeansParams = defineParameters(
    StringParam<Fixed<true>>("name", "Name"),
    LongParam("numClusters", "Number of Clusters", 4, Min(0)),
    FloatParam("encodingThreshold", "Encoding Threshold", 0.25, Min(0), Max(1)),
    LongParam("maxIter", "Max number of Iterations", 100, Min(1)));
```