### PR TITLE
Correct indexing bugs due to incorrect refactor in robustIteration()

### DIFF
--- a/include/algorithms/util/ARModel.hpp
+++ b/include/algorithms/util/ARModel.hpp
@@ -204,8 +204,8 @@ private:
     // Iterate to find new filtered input
     for (index i = 0; i < size; i++)
     {
-      const double prediction = fowardPrediction(estimates);
-      estimates[0] =
+      const double prediction = fowardPrediction(estimates + i);
+      estimates[i] =
           prediction +
           robustResidual(input[i], prediction, robustFactor * sqrt(mVariance));
     }


### PR DESCRIPTION
Fixes the indexing bug discussed today with @weefuzzy.

It could probably do with a quick check over to see that this looks similar to the code here:

https://github.com/flucoma/flucoma-core/blob/2011fc0b21d4ec597d973bc64657542768269452/include/algorithms/ARModel.hpp

Which I think is the last good version.