### PR TITLE
[Fix] Make error language more consistent

### DIFF
--- a/include/clients/nrt/CommonResults.hpp
+++ b/include/clients/nrt/CommonResults.hpp
@@ -34,7 +34,7 @@ static const std::string NoLabelSet{"LabelSet does not exist"};
 static const std::string NoDataFitted{"No data fitted"};
 static const std::string NotEnoughData{"Not enough data"};
 static const std::string EmptyLabel{"Empty label"};
-static const std::string EmptyId{"Empty id"};
+static const std::string EmptyId{"Empty identifier"};
 static const std::string BufferAlloc{"Can't allocate buffer"};
 static const std::string FileRead{"Couldn't read file"};
 static const std::string FileWrite{"Couldn't write file"};

--- a/include/clients/nrt/CommonResults.hpp
+++ b/include/clients/nrt/CommonResults.hpp
@@ -21,7 +21,7 @@ static const std::string PointNotFound{"Point not found"};
 static const std::string WrongPointSize{"Wrong Point Size"};
 static const std::string WrongPointNumber{"Wrong number of points"};
 static const std::string WrongNumInitial{"Wrong number of initial points"};
-static const std::string DuplicateLabel{"Label already in dataset"};
+static const std::string DuplicateLabel{"Identifier already in dataset"};
 static const std::string SmallDataSet{"DataSet is smaller than k"};
 static const std::string SmallK{"k is too small"};
 static const std::string LargeK{"k is too large"};

--- a/include/clients/nrt/CommonResults.hpp
+++ b/include/clients/nrt/CommonResults.hpp
@@ -21,7 +21,7 @@ static const std::string PointNotFound{"Point not found"};
 static const std::string WrongPointSize{"Wrong Point Size"};
 static const std::string WrongPointNumber{"Wrong number of points"};
 static const std::string WrongNumInitial{"Wrong number of initial points"};
-static const std::string DuplicateLabel{"Identifier already in dataset"};
+static const std::string DuplicateIdentifier{"Identifier already in dataset"};
 static const std::string SmallDataSet{"DataSet is smaller than k"};
 static const std::string SmallK{"k is too small"};
 static const std::string LargeK{"k is too large"};

--- a/include/clients/nrt/DataSetClient.hpp
+++ b/include/clients/nrt/DataSetClient.hpp
@@ -76,7 +76,7 @@ public:
       return Error(WrongPointSize);
     RealVector point(dataset.dims());
     point = buf.samps(0, dataset.dims(), 0);
-    return dataset.add(id, point) ? OK() : Error(DuplicateLabel);
+    return dataset.add(id, point) ? OK() : Error(DuplicateIdentifier);
   }
 
   MessageResult<void> getPoint(string id, BufferPtr data) const

--- a/include/clients/nrt/LabelSetClient.hpp
+++ b/include/clients/nrt/LabelSetClient.hpp
@@ -76,7 +76,7 @@ public:
     if (label.empty()) return Error(EmptyLabel);
     if (mAlgorithm.dims() == 0) { mAlgorithm = LabelSet(1); }
     StringVector point = {label};
-    return mAlgorithm.add(id, point) ? OK() : Error(DuplicateLabel);
+    return mAlgorithm.add(id, point) ? OK() : Error(DuplicateIdentifier);
   }
 
   MessageResult<string> getLabel(string id) const


### PR DESCRIPTION
In two cases the use of the word label is out of date with how we currently teach the toolkit. This has been replaced with identifier in the appropriate error message. Similarly `id` should be replaced with identifier as to not confuse native speakers.
