### PR TITLE
`NoveltySlice`: Fix reset after parameter change (issue #128)

### DIFF
--- a/include/algorithms/public/NoveltySegmentation.hpp
+++ b/include/algorithms/public/NoveltySegmentation.hpp
@@ -33,6 +33,7 @@ public:
   {
     mNovelty.init(kernelSize, filterSize, nDims);
     mDebounceCount = 1;
+    mPeakBuffer.setZero(); 
   }
 
   double processFrame(const RealVectorView input, double threshold,

--- a/include/clients/rt/NoveltySliceClient.hpp
+++ b/include/clients/rt/NoveltySliceClient.hpp
@@ -126,6 +126,7 @@ public:
       mLoudness.init(windowSize, sampleRate());
     }
     mFeature.resize(nDims);
+    mFrameOffset = 0; 
     mNovelty.init(get<kKernelSize>(), get<kFilterSize>(), nDims);
   }
 


### PR DESCRIPTION
fixes #128 by properly resetting the client's frame offset counter when the window / hop size change. Also zero the internal peak buffer for good measure. 