### PR TITLE
Enhance/max params

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,10 @@
 
 cmake_minimum_required (VERSION 3.11)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 get_directory_property(hasParent PARENT_DIRECTORY)
 
 #set module path at top level so wrapper projects can easily include fluid_version script
@@ -127,9 +131,6 @@ target_link_libraries(
 target_include_directories(HISSTools_FFT PUBLIC "${hisstools_SOURCE_DIR}")
 
 set_target_properties(HISSTools_FFT PROPERTIES
-    CXX_STANDARD 14
-    CXX_STANDARD_REQUIRED ON
-    CXX_EXTENSIONS OFF
     POSITION_INDEPENDENT_CODE ON
 )
 
@@ -152,11 +153,6 @@ add_library(
   "${hisstools_SOURCE_DIR}/AudioFile/OAudioFile.cpp"
 )
 
-set_target_properties(HISSTools_AudioFile PROPERTIES
-    CXX_STANDARD 14
-    CXX_STANDARD_REQUIRED ON
-    CXX_EXTENSIONS OFF
-)
 
 #Fluid Decomposition header-only target
 add_library(FLUID_DECOMPOSITION INTERFACE)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -9,12 +9,5 @@ foreach (EXAMPLE  describe)
 	)
 
 	target_compile_options(${EXAMPLE} PRIVATE ${FLUID_ARCH})
-
-	set_target_properties(${EXAMPLE}
-	    PROPERTIES
-	    CXX_STANDARD 14
-	    CXX_STANDARD_REQUIRED ON
-	    CXX_EXTENSIONS OFF
-	)
 	
 endforeach (EXAMPLE)

--- a/include/clients/common/FluidBaseClient.hpp
+++ b/include/clients/common/FluidBaseClient.hpp
@@ -33,7 +33,8 @@ enum ProcessState { kNoProcess, kProcessing, kDone, kDoneStillProcessing };
 
 struct ControlChannel {
   index count{0}; 
-  index size{-1}; 
+  index size{-1};
+  index max{-1}; 
 }; 
 
 class FluidBaseClient
@@ -47,7 +48,7 @@ public:
   ControlChannel controlChannelsOut() const noexcept { return mControlChannelsOut; }
   index maxControlChannelsOut() const noexcept
   {
-    return mMaxControlChannelsOut;
+    return mControlChannelsOut.max > -1 ? mControlChannelsOut.max : mControlChannelsOut.size;
   }
   bool   controlTrigger() const noexcept { return mControlTrigger; }
   index  audioBuffersIn() const noexcept { return mBuffersIn; }
@@ -71,10 +72,6 @@ protected:
   void audioChannelsOut(const index x) noexcept { mAudioChannelsOut = x; }
   void controlChannelsIn(const index x) noexcept { mControlChannelsIn = x; }
   void controlChannelsOut(const ControlChannel x) noexcept { mControlChannelsOut = x; }
-  void maxControlChannelsOut(const index x) noexcept
-  {
-    mMaxControlChannelsOut = x;
-  }
   void controlTrigger(const bool x) noexcept { mControlTrigger = x; }
   void audioBuffersIn(const index x) noexcept { mBuffersIn = x; }
   void audioBuffersOut(const index x) noexcept { mBuffersOut = x; }
@@ -97,8 +94,7 @@ private:
   index  mAudioChannelsIn = 0;
   index  mAudioChannelsOut = 0;
   index  mControlChannelsIn = 0;
-  ControlChannel  mControlChannelsOut {0,0};
-  index  mMaxControlChannelsOut = 0;
+  ControlChannel  mControlChannelsOut {0,0,-1};
   bool   mControlTrigger{false};
   index  mBuffersIn = 0;
   index  mBuffersOut = 0;

--- a/include/clients/common/FluidNRTClientWrapper.hpp
+++ b/include/clients/common/FluidNRTClientWrapper.hpp
@@ -528,7 +528,7 @@ struct StreamingControl
   {
     // To account for process latency we need to copy the buffers with padding
     std::vector<HostMatrix> inputData;
-    index                   nFeatures = client.controlChannelsOut().size;
+    index                   maxFeatures = client.maxControlChannelsOut();
     //      outputData.reserve(nFeatures);
     inputData.reserve(inputBuffers.size());
 
@@ -557,7 +557,7 @@ struct StreamingControl
     std::fill_n(std::back_inserter(inputData), inputBuffers.size(),
                 HostMatrix(nChans, nFrames + totalPadding));
 
-    HostMatrix outputData(nChans * nFeatures, nHops);
+    HostMatrix outputData(nChans * maxFeatures, nHops);
     double     sampleRate{0};
     // Copy input data
     for (index i = 0; i < nChans; ++i)
@@ -591,7 +591,7 @@ struct StreamingControl
 
         // for (index k = 0; k < nFeatures; ++k)
         //   outputs.emplace_back(outputData.row(k + i * nFeatures)(Slice(j, 1)));
-        outputs.push_back(outputData.col(j)(Slice(i * nFeatures, nFeatures)));
+        outputs.push_back(outputData.col(j)(Slice(i * maxFeatures, maxFeatures)));
 
         client.process(inputs, outputs, dummyContext);
 
@@ -603,7 +603,7 @@ struct StreamingControl
     }
 
     BufferAdaptor::Access thisOutput(outputBuffers[0]);
-
+    index nFeatures = client.controlChannelsOut().size;
     index latencyHops = client.latency() / controlRate;
     index keepHops = nHops - latencyHops;
 

--- a/include/clients/common/ParameterConstraints.hpp
+++ b/include/clients/common/ParameterConstraints.hpp
@@ -35,7 +35,22 @@ struct MinImpl
   constexpr void clamp(U& x, Tuple& /*params*/, Descriptor& d, Result* r) const
   {
     U oldX = x;
-    x = std::max<U>(x, value);
+    x = std::max<U>(x, static_cast<U>(value));
+    if (r && oldX != x)
+    {
+      r->set(Result::Status::kWarning);
+      r->addMessage(d.template get<N>().name, " value, ", oldX,
+                    ", below absolute minimum ", x);
+    }
+  }
+  
+  template <size_t Offset, size_t N, typename Tuple,
+            typename Descriptor>
+  constexpr void clamp(LongRuntimeMaxParam& x, Tuple& /*params*/, Descriptor& d, Result* r) const
+  {
+    index oldX = x();
+    index newx = std::max<index>(x(), value);
+    x.set(newx); 
     if (r && oldX != x)
     {
       r->set(Result::Status::kWarning);
@@ -75,17 +90,17 @@ struct LowerLimitImpl : public Relational
   {
     T oldV = v;
 
-    v = std::max<T>({v, std::get<Is + Offset>(params)...});
+    v = std::max<T>({v, std::get<Is + Offset>(params).get()...});
 
     if (r && oldV != v)
     {
       r->set(Result::Status::kWarning);
       std::array<T, sizeof...(Is)> constraintValues{
-          {std::get<Is + Offset>(params)...}};
+          {std::get<Is + Offset>(params).get()...}};
       index minPos = std::distance(
           constraintValues.begin(),
           std::min_element(constraintValues.begin(), constraintValues.end()));
-      std::array<const char*, sizeof...(Is)> constraintNames{
+      std::array<std::string_view, sizeof...(Is)> constraintNames{
           {d.template get<Is + Offset>().name...}};
       r->addMessage(d.template get<N>().name, " value (", oldV,
                     ") below parameter ", constraintNames[asUnsigned(minPos)],
@@ -113,7 +128,7 @@ struct UpperLimitImpl : public Relational
       index maxPos = std::distance(
           constraintValues.begin(),
           std::max_element(constraintValues.begin(), constraintValues.end()));
-      std::array<const char*, sizeof...(Is)> constraintNames{
+      std::array<std::string_view, sizeof...(Is)> constraintNames{
           {d.template get<Is + Offset>().name...}};
       r->addMessage(d.template get<N>().name, " value, ", oldV,
                     ", above parameter ", constraintNames[asUnsigned(maxPos)],

--- a/include/clients/common/ParameterTypes.hpp
+++ b/include/clients/common/ParameterTypes.hpp
@@ -41,6 +41,8 @@ struct Fixed
   static bool constexpr value{b};
 };
 
+struct Primary {};
+
 struct ParamTypeBase
 {
   constexpr ParamTypeBase(const char* n, const char* display)
@@ -71,6 +73,7 @@ struct LongT : ParamTypeBase
   const index fixedSize = 1;
   const type  defaultValue;
 };
+
 
 struct BufferT : ParamTypeBase
 {
@@ -249,12 +252,11 @@ struct ConstrainMaxFFTSize<true>
 class FFTParams
 {
 public:
-  constexpr FFTParams(intptr_t win, intptr_t hop, intptr_t fft)
-      : mWindowSize{win}, mHopSize{hop}, mFFTSize{fft}, trackWin{win},
-        trackHop{hop}, trackFFT{fft}
+  constexpr FFTParams(intptr_t win, intptr_t hop, intptr_t fft, intptr_t max = -1)
+      : mWindowSize{win}, mHopSize{hop}, mFFTSize{fft}, mMaxFFTSize{max},
+        trackWin{win}, trackHop{hop}, trackFFT{fft}
   {}
-
-
+  
   constexpr FFTParams(const FFTParams& p) noexcept = default;
   constexpr FFTParams(FFTParams&& p) noexcept = default;
 
@@ -264,7 +266,7 @@ public:
     mWindowSize = p.mWindowSize;
     mHopSize = p.mHopSize;
     mFFTSize = p.mFFTSize;
-
+    mMaxFFTSize = p.mMaxFFTSize;
     return *this;
   }
 
@@ -273,8 +275,13 @@ public:
     mWindowSize = p.mWindowSize;
     mHopSize = p.mHopSize;
     mFFTSize = p.mFFTSize;
-
+    mMaxFFTSize = p.mMaxFFTSize;
     return *this;
+  }
+
+  index maxSize() const noexcept
+  {
+    return mMaxFFTSize;
   }
 
   index fftSize() const noexcept
@@ -424,9 +431,10 @@ public:
   };
 
 private:
-  intptr_t mWindowSize{0};
-  intptr_t mHopSize{0};
-  intptr_t mFFTSize{0};
+  intptr_t mWindowSize;
+  intptr_t mHopSize;
+  intptr_t mFFTSize;
+  intptr_t mMaxFFTSize;
 
   ParameterTrackChanges<intptr_t> trackWin;
   ParameterTrackChanges<intptr_t> trackHop;
@@ -440,10 +448,85 @@ struct FFTParamsT : ParamTypeBase
   constexpr FFTParamsT(const char* name, const char* displayName,
                        index winDefault, index hopDefault, index fftDefault)
       : ParamTypeBase(name, displayName), defaultValue{winDefault, hopDefault,
-                                                       fftDefault}
+                                                       fftDefault,-1}
   {}
 
   const index fixedSize = 3;
+  const type  defaultValue;
+};
+
+class LongRuntimeMaxParam {
+public:
+  
+  constexpr LongRuntimeMaxParam(index val, index max)
+    : mValue(max < 0 ? val: std::min(val,max)), mMax(max < 0 ? val : max)
+  {}
+
+  constexpr LongRuntimeMaxParam(index val): LongRuntimeMaxParam(val,-1){}
+  //todo do I need this?
+  LongRuntimeMaxParam(std::reference_wrapper<index> val): LongRuntimeMaxParam(val.get(),-1){}
+
+  index operator()() const  { return mValue; }
+  operator fluid::index() const {return mValue; }
+  index max() const { return mMax; }
+  
+  void set(index val)
+  {
+    mValue = val;
+  }
+  
+  void clamp() { mValue = std::min(mValue,mMax);   }
+  
+  struct RuntimeMaxConstraint
+  {
+    template <index Offset, size_t N, typename Tuple, typename Descriptor>
+    constexpr void clamp(LongRuntimeMaxParam& v, Tuple&, Descriptor& d,
+                         Result* r) const
+    {
+       index oldValue = v;
+       v.clamp();
+       if(r && oldValue != v)
+       {
+          r->set(Result::Status::kWarning);
+          r->addMessage(d.template get<N>().name, " value, ", oldValue,
+                    ", above user defined maximum ", v.max());
+       }
+    }
+  };
+  
+  friend bool operator<(const LongRuntimeMaxParam& l, const LongRuntimeMaxParam& r)
+  {
+    return l() < r();
+  }
+  
+  friend bool operator>(const LongRuntimeMaxParam& l, const LongRuntimeMaxParam& r)
+  {
+    return r() < l();
+  }
+  
+  friend bool operator<=(const LongRuntimeMaxParam& l, const LongRuntimeMaxParam& r)
+  {
+    return !(l() > r());
+  }
+  
+  friend bool operator>=(const LongRuntimeMaxParam& l, const LongRuntimeMaxParam& r)
+  {
+    return !(l() < r());
+  }
+    
+private:
+  index mValue;
+  index mMax;
+};
+
+struct LongRuntimeMaxT: ParamTypeBase
+{
+  using type = LongRuntimeMaxParam;
+  constexpr LongRuntimeMaxT(const char* name, const char* displayName,
+                           index defaultValue)
+       : ParamTypeBase(name, displayName), defaultValue(defaultValue,-1)
+  {}
+  const index fixedSize = 2;
   const type  defaultValue;
 };
 
@@ -543,6 +626,14 @@ FFTParam(const char* name, const char* displayName, index winDefault,
           Fixed<false>{}};
 }
 
+template<typename IsPrimary = Fixed<false>, typename...Constraints>
+constexpr ParamSpec<LongRuntimeMaxT,IsPrimary,LongRuntimeMaxParam::RuntimeMaxConstraint,Constraints...>
+LongParamRuntimeMax(const char* name, const char* displayName, index defaultValue,  const Constraints&&...c)
+{
+  return { LongRuntimeMaxT(name, displayName,defaultValue),
+            std::make_tuple(LongRuntimeMaxParam::RuntimeMaxConstraint(), std::forward<const Constraints>(c)...),
+            IsPrimary()};
+}
 
 template <typename IsFixed = Fixed<false>, typename... Constraints>
 constexpr ParamSpec<StringT, IsFixed, Constraints...>
@@ -581,6 +672,18 @@ struct ParamLiterals<FFTParamsT>
     return {{p.winSize(), p.hopRaw(), p.fftRaw()}};
   }
 };
+
+template <>
+struct ParamLiterals<LongRuntimeMaxT>
+{
+   using type = index;
+   
+   static std::array<index,2> getLiteral(const LongRuntimeMaxParam& p)
+   {
+      return {{p(),p.max()}};
+   }
+};
+
 } // namespace impl
 
 template <typename T, size_t N>

--- a/include/clients/common/Result.hpp
+++ b/include/clients/common/Result.hpp
@@ -39,7 +39,7 @@ public:
     if (&r == this) return *this;
 
     mStatus = r.mStatus;
-    mMsg = std::stringstream(r.mMsg.str());
+    mMsg = std::ostringstream(r.mMsg.str());
     return *this;
   };
 
@@ -71,13 +71,13 @@ public:
 
   void reset()
   {
-    mMsg = std::stringstream();
+    mMsg = std::ostringstream();
     mStatus = Status::kOk;
   }
 
 private:
   Status            mStatus = Status::kOk;
-  std::stringstream mMsg;
+  std::ostringstream mMsg;
 };
 
 

--- a/include/clients/nrt/FluidSharedInstanceAdaptor.hpp
+++ b/include/clients/nrt/FluidSharedInstanceAdaptor.hpp
@@ -126,6 +126,12 @@ public:
       return {Result::Status::kWarning, name, " not found"};
   }
 
+  template<typename Func,typename... Args>
+  auto setPrimaryParameterValues(bool reportage,Func&& f, Args&&...args)
+  {
+     return mParams->params.setPrimaryParameterValues(reportage, std::forward<Func>(f),std::forward<Args>(args)...);
+  }
+  
   template <template <size_t N, typename T> class Func, typename... Args>
   auto setFixedParameterValues(bool reportage, Args&&... args)
   {

--- a/include/clients/rt/MFCCClient.hpp
+++ b/include/clients/rt/MFCCClient.hpp
@@ -31,23 +31,21 @@ enum MFCCParamIndex {
   kDrop0,
   kMinFreq,
   kMaxFreq,
-  kMaxNCoefs,
   kFFT,
   kMaxFFTSize
 };
 
 constexpr auto MFCCParams = defineParameters(
-    LongParam("numCoeffs", "Number of Cepstral Coefficients", 13, Min(2),
-              UpperLimit<kNBands, kMaxNCoefs>()),
-    LongParam("numBands", "Number of Bands", 40, Min(2),
+    LongParamRuntimeMax<Primary>("numCoeffs", "Number of Cepstral Coefficients", 13,
+              Min(2),
+              UpperLimit<kNBands>()),
+    LongParam<Primary>("numBands", "Number of Bands", 40, Min(2),
               FrameSizeUpperLimit<kFFT>(), LowerLimit<kNCoefs>()),
     LongParam("startCoeff", "Output Coefficient Offset", 0, Min(0),
               Max(1)), // this needs to be programmatically changed to start+num
                        // coeffs <= numBands as discussed
     FloatParam("minFreq", "Low Frequency Bound", 20, Min(0)),
     FloatParam("maxFreq", "High Frequency Bound", 20000, Min(0)),
-    LongParam<Fixed<true>>("maxNumCoeffs", "Maximum Number of Coefficients", 40,
-                           MaxFrameSizeUpperLimit<kMaxFFTSize>(), Min(2)),
     FFTParam<kMaxFFTSize>("fftSettings", "FFT Settings", 1024, -1, -1),
     LongParam<Fixed<true>>("maxFFTSize", "Maxiumm FFT Size", 16384));
 
@@ -59,10 +57,14 @@ public:
   using ParamSetViewType = ParameterSetView<ParamDescType>;
   std::reference_wrapper<ParamSetViewType> mParams;
 
-  void setParams(ParamSetViewType& p) { mParams = p; }
+  void setParams(ParamSetViewType& p)
+  {
+    mParams = p;
+    controlChannelsOut({1, get<kNCoefs>(), get<kNCoefs>().max()});
+  }
 
   template <size_t N>
-  auto& get() const
+  auto get() const -> decltype(mParams.get().template get<N>())
   {
     return mParams.get().template get<N>();
   }
@@ -72,13 +74,12 @@ public:
   MFCCClient(ParamSetViewType& p)
       : mParams{p}, mSTFTBufferedProcess(get<kMaxFFTSize>(), 1, 0),
         mMelBands(get<kMaxFFTSize>(), get<kMaxFFTSize>()),
-        mDCT(get<kMaxFFTSize>(),
-             get<kMaxNCoefs>() + 1) // + 1 for possibility of dropping 0th
+        mDCT(get<kMaxFFTSize>(), get<kNCoefs>().max() + 1)
   {
     mBands = FluidTensor<double, 1>(get<kNBands>());
     mCoefficients = FluidTensor<double, 1>(get<kNCoefs>() + get<kDrop0>());
     audioChannelsIn(1);
-    controlChannelsOut({1, get<kMaxNCoefs>()});
+    controlChannelsOut({1, get<kNCoefs>(), get<kNCoefs>().max()});
     setInputLabels({"audio input"});
     setOutputLabels({"MFCCs"});
   }
@@ -107,6 +108,7 @@ public:
                      get<kFFT>().frameSize(), sampleRate(),
                      get<kFFT>().winSize());
       mDCT.init(get<kNBands>(), get<kNCoefs>() + !has0);
+      controlChannelsOut({1, get<kNCoefs>()});
     }
 
     mSTFTBufferedProcess.processInput(
@@ -118,7 +120,7 @@ public:
   
       output[0](Slice(0, get<kNCoefs>())) <<=
         mCoefficients(Slice(get<kDrop0>(), get<kNCoefs>()));
-      output[0](Slice(get<kNCoefs>(), get<kMaxNCoefs>() - get<kNCoefs>())).fill(0); 
+      output[0](Slice(get<kNCoefs>(), get<kNCoefs>().max() - get<kNCoefs>())).fill(0);
   }
 
   index latency() { return get<kFFT>().winSize(); }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -100,6 +100,12 @@ target_compile_definitions(TestUtils INTERFACE
   APPROVAL_TESTS_HIDE_DEPRECATED_CODE=1
 )
 
+if(APPLE)
+  target_compile_definitions(TestUtils INTERFACE   
+    CATCH_CONFIG_NO_CPP17_UNCAUGHT_EXCEPTIONS
+  )
+endif()
+
 function(add_test_executable target_name source_file)
   add_executable(${target_name} ${source_file})
   target_link_libraries(${target_name} PUBLIC TestUtils)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -99,7 +99,6 @@ target_link_libraries(TestUtils INTERFACE
 target_compile_definitions(TestUtils INTERFACE 
   APPROVAL_TESTS_HIDE_DEPRECATED_CODE=1
 )
-target_compile_features(TestUtils INTERFACE cxx_std_14)
 
 function(add_test_executable target_name source_file)
   add_executable(${target_name} ${source_file})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,11 +7,6 @@ add_subdirectory(test_signals)
 
 # a handler to catch sigabrt for us on death tests
 add_library(AbortHandler OBJECT AbortHandler.cpp)
-set_target_properties(AbortHandler PROPERTIES 
-  CXX_STANDARD 14
-  CXX_STANDARD_REQUIRED ON
-  CXX_EXTENSIONS  OFF
-)
 
 # function (add_assert_fail_test testname sourcedir)
 #   try_compile(
@@ -60,9 +55,6 @@ function (_add_one_compile_test testname sourcefile should_fail)
   set_target_properties(${testname} PROPERTIES 
       EXCLUDE_FROM_ALL true
       EXCLUDE_FROM_DEFAULT_BUILD true
-      CXX_STANDARD 14
-      CXX_STANDARD_REQUIRED ON
-      CXX_EXTENSIONS OFF
       POSITION_INDEPENDENT_CODE ON
   )                                               
   target_compile_definitions(${testname} PRIVATE ${testname})
@@ -112,11 +104,6 @@ target_compile_features(TestUtils INTERFACE cxx_std_14)
 function(add_test_executable target_name source_file)
   add_executable(${target_name} ${source_file})
   target_link_libraries(${target_name} PUBLIC TestUtils)
-  set_target_properties(${target_name} PROPERTIES 
-    CXX_STANDARD 14
-    CXX_STANDARD_REQUIRED ON
-    CXX_EXTENSIONS  OFF
-  )
 endfunction()
 
 add_test_executable(TestFluidTensor data/TestFluidTensor.cpp)


### PR DESCRIPTION
For parameters that need to have a maximum set at Client instantiation (because it implies allocation), introduce a new unified parameter type that holds both the value and its runtime maximum. This allows us to deal with longstanding annoyances to do with things like the output size in BufMFCC etc. 

`MFCCClient` is updated to provide a proof of concept 