### PR TITLE
[Enhance] ChoicesParam for LoudnessClient and PitchClient

### DIFF
--- a/include/clients/common/FluidNRTClientWrapper.hpp
+++ b/include/clients/common/FluidNRTClientWrapper.hpp
@@ -391,8 +391,8 @@ public:
     //    return {FFTParams::padding(fftSettings,
     //    userPaddingParamValue),userPaddingParamValue};
     index            userPaddingParamValue = get<ParamOffset - 1>();
-    constexpr size_t WinOffset = 2;
-    constexpr size_t HopOffset = 3;
+    constexpr size_t WinOffset = 3;
+    constexpr size_t HopOffset = 4;
 
     assert((mParams.get().template descriptorAt<ParamOffset + WinOffset>()).name == "windowSize");
 

--- a/include/clients/rt/LoudnessClient.hpp
+++ b/include/clients/rt/LoudnessClient.hpp
@@ -63,11 +63,10 @@ public:
   static constexpr auto& getParameterDescriptors() { return LoudnessParams; }
 
   LoudnessClient(ParamSetViewType& p)
-      : mParams(p), mAlgorithm{get<kMaxWindowSize>()},
-        mMaxOutputSize{asSigned(get<kSelect>().count())}
+      : mParams(p), mAlgorithm{get<kMaxWindowSize>()}
   {
     audioChannelsIn(1);
-    controlChannelsOut({1,mMaxOutputSize});
+    controlChannelsOut({1,2});
     setInputLabels({"audio input"});
     setOutputLabels({"loudness and peak amplitude"});
     mDescriptors = FluidTensor<double, 1>(2);
@@ -103,14 +102,14 @@ public:
     
     auto selection = get<kSelect>();
     index numSelected = asSigned(selection.count());
-    index numOuts = std::min<index>(mMaxOutputSize,numSelected);
+    index numOuts = std::min<index>(2,numSelected);
 
     for(index i = 0, j = 0 ; i < 2 && j < numOuts; ++i)
     {
       if(selection[asUnsigned(i)]) output[0](j++) = static_cast<T>(mDescriptors(i)); 
     }
-    if(mMaxOutputSize > numSelected)
-      for(index i = (mMaxOutputSize - numSelected); i < mMaxOutputSize; ++i)
+    if(2 > numSelected)
+      for(index i = (2 - numSelected); i < 2; ++i)
         output[0](i) = 0;
   }
 
@@ -134,7 +133,7 @@ private:
   BufferedProcess                                    mBufferedProcess;
   FluidTensor<double, 1>                             mDescriptors;
 
-  index mMaxOutputSize;
+  index 2;
 };
 } // namespace loudness
 

--- a/include/clients/rt/LoudnessClient.hpp
+++ b/include/clients/rt/LoudnessClient.hpp
@@ -34,7 +34,7 @@ enum LoudnessParamIndex {
 };
 
 constexpr auto LoudnessParams = defineParameters(
-    ChoicesParam("select","Selection of Outputs","loudness","truepeak"),
+    ChoicesParam("select","Selection of Outputs","loudness","peak"),
     EnumParam("kWeighting", "Apply K-Weighting", 1, "Off", "On"),
     EnumParam("truePeak", "Compute True Peak", 1, "Off", "On"),
     LongParam("windowSize", "Window Size", 1024, UpperLimit<kMaxWindowSize>()),

--- a/include/clients/rt/SpectralShapeClient.hpp
+++ b/include/clients/rt/SpectralShapeClient.hpp
@@ -107,13 +107,14 @@ public:
     index numSelected = asSigned(selection.count());
     index numOuts = std::min<index>(mMaxOutputSize,numSelected);
     controlChannelsOut({1, numOuts, mMaxOutputSize});
-    for(index i = 0, j = 0 ; i < mMaxOutputSize && j < numOuts; ++i)
+    
+    for (index i = 0, j = 0; i < mMaxOutputSize && j < numOuts; ++i)
     {
-       if(selection[asUnsigned(i)]) output[0](j++) = static_cast<T>(mDescriptors(i)); 
+      if (selection[asUnsigned(i)])
+        output[0](j++) = static_cast<T>(mDescriptors(i));
     }
-    if(mMaxOutputSize > numSelected)
-      for(index i = (mMaxOutputSize - numSelected); i < mMaxOutputSize; ++i)
-        output[0](i) = 0;
+    
+    output[0](Slice(numOuts, mMaxOutputSize - numOuts)).fill(0); 
   }
 
   index latency() { return get<kFFT>().winSize(); }


### PR DESCRIPTION
In keeping with the consistency of SpectralShape and BufStats, I think that Loudness should also include a ChoicesParam. This implements it in what I thought was the most similar way to SpectralShape and which is stylistically pretty much the same.
