### PR TITLE
[POC] Scaling Options: Exponent and Conversion

### DIFF
--- a/include/clients/nrt/BufScaleClient.hpp
+++ b/include/clients/nrt/BufScaleClient.hpp
@@ -30,7 +30,7 @@ enum {
   kInHigh,
   kOutLow,
   kOutHigh,
-  kScale,
+  kConvert,
   kExponent,
   kClip
 };
@@ -120,13 +120,13 @@ public:
       };
 
     auto   clipFn = clippingFunctions[asUnsigned(get<kClip>())];
-    auto   scaleFn = scalingFunctions[asUnsigned(get<kScale>())];
+    auto   scaleFn = scalingFunctions[asUnsigned(get<kConvert>())];
     double inLow = get<kInLow>();
     double outLow = get<kOutLow>();
     double inHigh = get<kInHigh>();
     double outHigh = get<kOutHigh>();
     double exponent = get<kExponent>();
-    
+
     // process
     tmp.apply([&](double& x) {
       x = scaleFn(x);

--- a/include/clients/nrt/BufScaleClient.hpp
+++ b/include/clients/nrt/BufScaleClient.hpp
@@ -46,8 +46,7 @@ constexpr auto BufScaleParams =
                      FloatParam("inputHigh", "Input High Range", 1),
                      FloatParam("outputLow", "Output Low Range", 0),
                      FloatParam("outputHigh", "Output High Range", 1),
-                     EnumParam("scale", "Scaling Function", 0, "None", "dbtoa", "atodb", "mtof", "ftom"),
-                     FloatParam("exponent", "Scaling Exponent", Min(1)),
+                     EnumParam("convert", "Pre-scaling conversion", 0, "None", "dbtoa", "atodb", "mtof", "ftom"),
                      FloatParam("exponent", "Scaling Exponent", 1.0, Min(1.0)),
                      EnumParam("clipping", "Optional Clipping", 0, "None",
                                "Minimum", "Maximum", "Both"));

--- a/include/clients/nrt/BufScaleClient.hpp
+++ b/include/clients/nrt/BufScaleClient.hpp
@@ -108,6 +108,16 @@ public:
           return std::min(std::max(x, low), high);
         }};
 
+    // scaling functions
+    using scaleFnType = double (*)(double);
+
+    static const std::array<scaleFnType, 5> scalingFunctions = {
+        [](double x) { return x; },
+        [](double x) { return pow(10.0, x / 20.0); }, 
+        [](double x) { return std::max(log10(x) * 20.0, -157.226593); },
+        [](double x) { return exp2((x - 69.0) / 12.0) * 440.0; },
+        [](double x) { return log2(x / 440.0) * 12.0 + 69.0; }
+      };
     auto   clipFn = clippingFunctions[asUnsigned(get<kClip>())];
     double outLow = get<kOutLow>();
     double outHigh = get<kOutHigh>();

--- a/include/clients/nrt/BufScaleClient.hpp
+++ b/include/clients/nrt/BufScaleClient.hpp
@@ -118,11 +118,13 @@ public:
         [](double x) { return exp2((x - 69.0) / 12.0) * 440.0; },
         [](double x) { return log2(x / 440.0) * 12.0 + 69.0; }
       };
+
     auto   clipFn = clippingFunctions[asUnsigned(get<kClip>())];
+    auto   scaleFn = scalingFunctions[asUnsigned(get<kScale>())];
+    double inLow = get<kInLow>();
     double outLow = get<kOutLow>();
+    double inHigh = get<kInHigh>();
     double outHigh = get<kOutHigh>();
-    double scale = (outHigh - outLow) / (get<kInHigh>() - get<kInLow>());
-    double offset = outLow - (scale * get<kInLow>());
 
     // process
     tmp.apply([&](double& x) {

--- a/include/clients/nrt/BufScaleClient.hpp
+++ b/include/clients/nrt/BufScaleClient.hpp
@@ -30,6 +30,8 @@ enum {
   kInHigh,
   kOutLow,
   kOutHigh,
+  kScale,
+  kExponent,
   kClip
 };
 
@@ -44,6 +46,8 @@ constexpr auto BufScaleParams =
                      FloatParam("inputHigh", "Input High Range", 1),
                      FloatParam("outputLow", "Output Low Range", 0),
                      FloatParam("outputHigh", "Output High Range", 1),
+                     EnumParam("scale", "Scaling Function", 0, "None", "dbtoa", "atodb", "mtof", "ftom"),
+                     FloatParam("exponent", "Scaling Exponent", 1),
                      EnumParam("clipping", "Optional Clipping", 0, "None",
                                "Minimum", "Maximum", "Both"));
 

--- a/include/clients/nrt/BufScaleClient.hpp
+++ b/include/clients/nrt/BufScaleClient.hpp
@@ -46,7 +46,7 @@ constexpr auto BufScaleParams =
                      FloatParam("inputHigh", "Input High Range", 1),
                      FloatParam("outputLow", "Output Low Range", 0),
                      FloatParam("outputHigh", "Output High Range", 1),
-                     EnumParam("convert", "Pre-scaling conversion", 0, "None", "dbtoa", "atodb", "mtof", "ftom"),
+                     EnumParam("convert", "Pre-Scaling Conversion", 0, "None", "dbtoa", "atodb", "mtof", "ftom"),
                      FloatParam("exponent", "Scaling Exponent", 1.0, Min(1.0)),
                      EnumParam("clipping", "Optional Clipping", 0, "None",
                                "Minimum", "Maximum", "Both"));

--- a/include/clients/nrt/BufScaleClient.hpp
+++ b/include/clients/nrt/BufScaleClient.hpp
@@ -48,6 +48,7 @@ constexpr auto BufScaleParams =
                      FloatParam("outputHigh", "Output High Range", 1),
                      EnumParam("scale", "Scaling Function", 0, "None", "dbtoa", "atodb", "mtof", "ftom"),
                      FloatParam("exponent", "Scaling Exponent", Min(1)),
+                     FloatParam("exponent", "Scaling Exponent", 1.0, Min(1.0)),
                      EnumParam("clipping", "Optional Clipping", 0, "None",
                                "Minimum", "Maximum", "Both"));
 

--- a/include/clients/nrt/BufScaleClient.hpp
+++ b/include/clients/nrt/BufScaleClient.hpp
@@ -47,7 +47,7 @@ constexpr auto BufScaleParams =
                      FloatParam("outputLow", "Output Low Range", 0),
                      FloatParam("outputHigh", "Output High Range", 1),
                      EnumParam("scale", "Scaling Function", 0, "None", "dbtoa", "atodb", "mtof", "ftom"),
-                     FloatParam("exponent", "Scaling Exponent", 1),
+                     FloatParam("exponent", "Scaling Exponent", Min(1)),
                      EnumParam("clipping", "Optional Clipping", 0, "None",
                                "Minimum", "Maximum", "Both"));
 

--- a/include/clients/nrt/BufScaleClient.hpp
+++ b/include/clients/nrt/BufScaleClient.hpp
@@ -129,8 +129,13 @@ public:
     
     // process
     tmp.apply([&](double& x) {
-      x *= scale;
-      x += offset;
+      x = scaleFn(x);
+      // x *= scale;
+      // x += offset;
+      x = ((x-inLow)/(inHigh-inLow) == 0) ? outLow 
+          : (((x-inLow)/(inHigh-inLow)) > 0) 
+          ? (outLow + (outHigh-outLow) * pow(((x-inLow)/(inHigh-inLow)), exponent)) 
+          : (outLow + (outHigh-outLow) * -pow(((-x+inLow)/(inHigh-inLow)), exponent));
       x = clipFn(x, outLow, outHigh);
     });
 

--- a/include/clients/nrt/BufScaleClient.hpp
+++ b/include/clients/nrt/BufScaleClient.hpp
@@ -125,7 +125,8 @@ public:
     double outLow = get<kOutLow>();
     double inHigh = get<kInHigh>();
     double outHigh = get<kOutHigh>();
-
+    double exponent = get<kExponent>();
+    
     // process
     tmp.apply([&](double& x) {
       x *= scale;


### PR DESCRIPTION
This PoC adds two features to the BufScaleClient. Potential documentation is also located at https://github.com/flucoma/flucoma-docs/pull/111.

## Exponent

A new parameter, `exponent` is introduced which allows you to add a base exponential value to the scaling. It is lifted directly from the Max `scale` object. With a default of 1 this does nothing and is linear, but higher values create steeper "curves".

## Conversion Functions

A new enum parameter, `convert` (I thought `scale` was a bit confusing) allows you to map the input data with a set of predefined functions prior to scaling. This comes in four flavours:

1) None (default)
2) dbtoa
3) atodb
4) mtof
5) ftom

These would be really useful in particular for quickly drawing up weights for stats or as a more general purpose tool for scaling one's loudness values amongst other things.

---

Patch below shows the various things it would add and their interface:

<details>
<pre><code>
----------begin_max5_patcher----------
1633.3oc4assbhiCD8YxWgJdZ2ZIT59k8o7eryVSY.QFOquvZaxjcmZy29JK
YG7jI.BbSBSMuDiEFZ0m9ntOsP4q2LY5hxGs0SQ+N5OPSl70alLwOT6.S5te
xz7jGWlkT6eroE1uTt3ySmEdqF6iM9gaPK5GqXadZQlsw+7jcCVts4kitIoY
4mRKt+iU1kMgYggKmimgDgKTZ+eQ+Y2mI70z7OargOvzEIE2O842Ncke93li
2RvlosC9e2bS6elEoGlaqqSt29ctHwHlaLJEgfHZd6KoXMhH4y0DlRSQDldt
vPXXi6kX2nTkY36Sc9jgSjh9u5rzB6xxsE9ue1qAezSE9TJVKhIEh1KDiG+3
lCge6A6jmC1sG1w5rsoqluX6ZZVZcyTP7zNhhjvaunhfn3s8q6r7KgyVuLIy
9D5tkkEOXqZPLzc0kaqVZQ4oqRKJabq7heMC83qYzDOHHTGGKlNauAdJ3XQK
vSc.B5tU15lzhjlzxhyBDhHwAwy7oX7nHDD.AgVyLutoxljiTm.4+3Qbt16k
g07mY.2nOGWso796yrfF4nFi+Bu+u62YRKd83l4Y3cSRURtswV8QaQxhL+GD
CWH8uce2UkHBFitKYYS5CVDAzzZLleQLgJGQAPi.PVr8wMUnpjhUk4+B9Cen
ct8qneyQAAkDvbIxEy7kRONk9U84yJU9eUmktxVA6hyPkIFKjWhcLB8rCvqI
uQ7ZWR501pm1ka1UxJIeS8dxacxUpHDAYPVZhLhx1qyJS7ny9443yIlurLO2
Vz7cXP8F2zsJIq9SIarn0YIMENEgnlRTR+yttrnoN8e8yPZaJ3nwF79wFsLT
4JTDuOm3.jYfGqoPpr8VWzPI4LkDcqizJkN02JzsZ2fLtlcP4papr0NTzWR+
iW.AsFb.OH9DBF0Ypm04EW4xYU9peDMazxY0bHIG34tUoZtF4dg6hq6G7blj
Kw52UdgRq.gWHtx4EcYE.gWHeK5xg.Skhd+l68ah.OBItZEjKHB0HQIHrS+G
kCZXV58Vs4LE+n0WjH7vBhtHcsMyMvyUFgMdi6X37wDuOq884y0aSgQKKSpC
oiBRZIgsjAexgSE8fx95Eijl4FL2NHn8kjGrqKqxe58EG3TXfAx6ALrul4KS
V0lY.4rWFpNs.QOoTdG.tHLOdwBhhID1YlEPBYMs9NBbd5ttA1aduSugfNeN
vQHBMD8CH4P1Ofqw2xhAuwEQ7eXoBy+8gLjCo8WbQKi26stXLLQ3tj.gKD4X
1aRI4BTG2SrgoHNe35WE9bW9Rei6lc+R0oWTJeP5dT86xU+rzuKWvgnuFt9J
uuFQHwOD80vM+DzuKiigfWHvW47htrBPvKDjef52s2ugneWA8Mne2iW0.Dhv
H6HVv9gsi3dFADcDK.UQbV41UdUDqVb42VbCdmJAR3XMrWUBRXUIPl6PcI2f
t0LWnwLpSjP6Obgq0Ls7csZP+uK3XUIbsuq3TLGLUB.uq3TkiZPaEGvHZc6K
HJkvbIObODJHAc509OEBFrXN9GHE.ctMDB.XW+a3cvaGY0c1EYqP5Ku8Dnw0
PYbBVNl35YkCKoooZ2V51dWW0cO8EniuQ3mur6XaRzm6lePvrXOpC9OtOM6K
N.q9oW63eKlDN6ccFu+zBg1MAGb1zF9PhvC8p3dzVRDik3.XIO9cTS0dH+F9
T4oq1TlVzzAjFst8P3HT9huFmnq96F8riF0rCFjvbJHwHsEIJaY.wV7nrkSf
JhLVdqNJSQfXIRLHX+7YbVJF7y.gOoiwRs623nCTssibbKIfvRwjzre5LNKE
y52W.wuHQl1kyp8zDR8sMpEgRve6cgBWco772sqjUU6YBbumvNXcjuEWe1zj
wY5XV.qgHsjLl0uJHVUIioFxKlN.AmQYZ0AqsJHs7LN0DNsqpmuCZVmLFMGR
HpzJhQxg.DKESBUA8RD5ixzbygB8bpZP1HNVLHaT+c8xnIWrrQrXJUvfHZwh
AxXWj7dQYZ9AqcXLCBVJ0fXU2MgPEkvtXgJQLoaDPjSUDS1aAF.8C7XJF19O
Uv3sTTb.HTewwwXIJ.VhEi5q9oy20qbxlMtN9q6dZuQllm74ROUUOyeaZQ3V
+NVNsx9PZ+y62i9oIUtV+ab88usJbTqdTF1Qno4kNRew1ztUuN2yYR+tPzdr
rp2jD7D+lUby+cy+CewJid.
-----------end_max5_patcher-----------
</code></pre>

</details>