### PR TITLE
Attempt to correct novelty object latency reporting

### DIFF
--- a/include/clients/rt/NoveltyFeatureClient.hpp
+++ b/include/clients/rt/NoveltyFeatureClient.hpp
@@ -179,7 +179,7 @@ public:
     index filterSize = get<kFilterSize>();
     if (filterSize % 2) filterSize++;
     return get<kFFT>().hopSize() *
-           (1 + ((get<kKernelSize>() + 1) >> 1) + (filterSize >> 1));
+      (((get<kKernelSize>() + 1) >> 1) + (filterSize >> 1)) + get<kFFT>().winSize();
   }
 
   AnalysisSize analysisSettings() 

--- a/include/clients/rt/NoveltySliceClient.hpp
+++ b/include/clients/rt/NoveltySliceClient.hpp
@@ -191,7 +191,7 @@ public:
     index filterSize = get<kFilterSize>();
     if (filterSize % 2) filterSize++;
     return get<kFFT>().hopSize() *
-           (1 + ((get<kKernelSize>() + 1) >> 1) + (filterSize >> 1));
+           (1 + ((get<kKernelSize>() + 1) >> 1) + (filterSize >> 1)) + get<kFFT>().winSize();
   }
 
   void reset()


### PR DESCRIPTION
This is my attempt to correct latency reporting for novelty. My assumptions are:

- That the FFT window needs compensating
- That both objects require compensating for half the filter (rounded up - based on the pre-existing approach) and half the kernel size
- That the slicer requires an additional hop for the peak finder

The previous state was that these were the same in both cases, neither compensating for the FFT window and BOTH correcting for an additional hop that I assume is the hop for the peak finder (which needs to lookahead by one).

I can probably provide audio and a test file to demonstrate why I think this is  better if needed, but I'd need some time to put it together.