### PR TITLE
Add an NRT client to calculate the novelty feature on data in a buffer

### DIFF
--- a/FlucomaClients.cmake
+++ b/FlucomaClients.cmake
@@ -107,6 +107,7 @@ add_client(BufThreadDemo clients/nrt/FluidThreadTestClient.hpp CLASS NRTThreaded
 add_client(BufThresh clients/nrt/BufThreshClient.hpp CLASS NRTThreadedBufferThreshClient )
 add_client(BufTransientSlice clients/rt/TransientSliceClient.hpp CLASS NRTThreadedTransientSliceClient )
 add_client(BufTransients clients/rt/TransientClient.hpp CLASS NRTThreadedTransientsClient )
+add_client(BufDataNoveltyFeature clients/nrt/NoveltyFeatureDataClient.hpp CLASS NRTThreadedNoveltyFeatureDataClient )
 add_client(Chroma clients/rt/ChromaClient.hpp CLASS RTChromaClient )
 add_client(Gain clients/rt/GainClient.hpp CLASS RTGainClient NOINSTALL)
 add_client(HPSS clients/rt/HPSSClient.hpp CLASS RTHPSSClient )

--- a/include/clients/nrt/NoveltyFeatureDataClient.hpp
+++ b/include/clients/nrt/NoveltyFeatureDataClient.hpp
@@ -1,0 +1,156 @@
+/*
+Part of the Fluid Corpus Manipulation Project (http://www.flucoma.org/)
+Copyright 2017-2019 University of Huddersfield.
+Licensed under the BSD-3 License.
+See license.md file in the project root for full license information.
+This project has received funding from the European Research Council (ERC)
+under the European Union’s Horizon 2020 research and innovation programme
+(grant agreement No 725899).
+*/
+
+#pragma once
+
+#include "../common/FluidBaseClient.hpp"
+#include "../common/FluidNRTClientWrapper.hpp"
+#include "../common/ParameterConstraints.hpp"
+#include "../common/ParameterTypes.hpp"
+#include "../../algorithms/public/NoveltyFeature.hpp"
+
+namespace fluid {
+namespace client {
+
+enum NoveltyDataParamIndex {kSource, kOffset, kNumFrames, kStartChan, kNumChans, kOutput, kKernelSize,kFilterSize};
+
+auto constexpr NoveltyDataParams = defineParameters(
+  InputBufferParam("source","Source Buffer"),
+  LongParam("startFrame","Source Offset",0,Min(0)),
+  LongParam("numFrames","Number of Frames",-1),
+  LongParam("startChan","Start Channel",0,Min(0)),
+  LongParam("numChans","Number of Channels",-1),
+  BufferParam("output", "Output Buffer"),
+  LongParam("kernelSize", "Kernel Size", 3, Min(3), Odd()),
+  LongParam("filterSize", "Smoothing Filter Size", 1, Min(1))
+ );
+
+
+class NoveltyFeatureDataClient: public FluidBaseClient, public OfflineIn, public OfflineOut
+{
+
+public:
+    
+  using ParamDescType = decltype(NoveltyDataParams);
+  using ParamSetViewType = ParameterSetView<ParamDescType>;
+
+  NoveltyFeatureDataClient(ParamSetViewType& p)
+  : mParams{p}
+  {}
+
+  template <std::size_t N>
+  auto& get() noexcept
+  {
+    return mParams.get().template get<N>();
+  }
+    
+  void setParams(ParamSetViewType& p)
+  {
+    mParams = p;
+  }
+    
+  static constexpr auto& getParameterDescriptors() { return NoveltyDataParams; }
+
+  index latency()
+  {
+    index filterSize = get<kFilterSize>();
+    if (filterSize % 2) filterSize++;
+    return ((get<kKernelSize>() + 1) >> 1) + (filterSize >> 1);
+  }
+    
+  template<typename T>
+  Result process(FluidContext&)
+  {
+    if(!get<kSource>().get())
+      return {Result::Status::kError, "No input buffer supplied"};
+
+    BufferAdaptor::ReadAccess source(get<kSource>().get());
+
+    if(!source.exists())
+        return {Result::Status::kError, "Input buffer not found"};
+
+    if(!source.valid())
+        return {Result::Status::kError, "Can't access input buffer"};
+
+    {
+        BufferAdaptor::Access idx(get<kOutput>().get());
+
+        if(!idx.exists())
+            return {Result::Status::kError, "Output buffer not found"};
+    }
+
+    index numFrames = get<kNumFrames>() == -1
+      ? (source.numFrames() - get<kOffset>())
+      : get<kNumFrames>();
+    index numChannels = get<kNumChans>() == -1
+      ? (source.numChans() - get<kStartChan>())
+      : get<kNumChans>();
+      
+    index kernelSize = get<kKernelSize>();
+    index filterSize = get<kFilterSize>();
+      
+    algorithm::NoveltyFeature processor(kernelSize, filterSize);
+
+    auto inputData = FluidTensor<double,1>(numChannels);
+    auto outputData = FluidTensor<double,1>(numFrames);
+      
+    processor.init(kernelSize, filterSize, numChannels);
+          
+    index preRoll = latency();
+    index chanOffset = get<kStartChan>();
+    index offset = get<kOffset>();
+      
+    auto getInput = [&](index idx)
+    {
+        // FIXME: make this nicer
+
+        for (index j = 0; j < numChannels; j++)
+            inputData(j) = source.samps(idx, 1, chanOffset + j)(0);
+    };
+      
+    for (index i = 0; i < preRoll; i++)
+    {
+        getInput(offset + i);
+        processor.processFrame(inputData);
+    }
+      
+    offset += preRoll;
+      
+    for (index i = 0; i < numFrames - preRoll; i++)
+    {
+        getInput(offset + i);
+        outputData(i) = processor.processFrame(inputData);
+    }
+
+    // FIXME: consider if there should be a "default input"
+      
+    inputData.fill(0.0);
+
+    for (index i = numFrames - preRoll; i < numFrames; i++)
+        outputData(i) = processor.processFrame(inputData);
+    
+    BufferAdaptor::Access idx(get<kOutput>().get());
+        
+    Result resizeResult =
+    idx.resize(numFrames, 1, source.sampleRate());
+    if (!resizeResult.ok()) return resizeResult;
+        
+    idx.samps(0) <<= outputData;
+    
+    return {Result::Status::kOk,""};
+  }
+
+  std::reference_wrapper<ParamSetViewType> mParams;
+};
+
+using NRTThreadedNoveltyFeatureDataClient = NRTThreadingAdaptor<ClientWrapper<NoveltyFeatureDataClient>>;
+
+} // namespace client
+} // namespace fluid


### PR DESCRIPTION
This PR addresses (for novelty feature, but not slicing) PR #148.

In max this adds the fluid.bufdatanoveltyfeature~ object (and similar for other environments).

Here's a patch to compare with fluid.bufnoveltyfeature~. Without the latency changes in #154 the overlaid outputs will be offer by window_size / hop_size. With that PR also they align.

<pre><code>
----------begin_max5_patcher----------
2668.3oc6bs0qaabD9Yc9UPP3BjDbLydkKYexoE8sBTff1TfXGHPIsRm0lhT
fj53icP7u8tWHkHEuHRIRIiT6GjNZWdYlu4xN6Ly5e+gY1KhegmZa8Wsdq0r
Y+9CyloGRMvr7eOydavKKCCR0Wl8x3sa4QY1OZlKi+Rld7eZ062mlYshmtLQ
rKKNwZWPRvVKwZ0XhD9phaYWBOU9DBxDwQyCEQ7kw6izODbwUDjs7IQzl4I7
kYFhC6hc.OZA8wNHOJCR.l+AwxA8Xp4P.Gf0uk+Hh1uUDExyzDMLePwJMoFu
38uFSrOdkw6yJtTfZv+3gGTe73UBI+LekkH0Zw90QwOyCy9zZdP19D9WdWz6
h9ag644ytJHK3jqn3Y0W3gQzvCAQbnR.gAz+hM..AQmd.4+jxsBrx3R8jTwl
nfP614HJyyAI4EephU7GtDFgldF5eFGrRxQqEgRFKR9mRd5So7NXKHFoEMdZ
sYyOFFaAGO1Zw9rr3nhmm4gk8ocbCoZuHHZi8ABqCYTAePJ9r2bCz6HVI8Vv
y3Iy4QAKB0z.nQNEdAbZD+ixWWM42Nq+dhzhiO+eK0I6gxHj4qXQOswFBMDF
0sEwV4WJOImEx4gY1JMqm4IoRWkkdvyrC1sqzvyJcKJF+8w5Gj2iGFRDYFBe
XnD9yhh6GbXzfDIqmI4aoSHMs+hagiR0iIdEOIZu3fTPKBxIIMXGIkgo6BVZ
tYkLoX5ifoGwn6CUe4B0HJl3dDLkByMgwK+.eUYhyNdGORDUd0iJSuhuNXeX
170wQYohOqo.nRurg4WmSgMNohGLKokHN3hZl8lDwp3HEQTQRnFt30IMu0dq
TedjYzWQTvtFtYolgDVZYxTIStOcQPhRPkaQfJlLKNNr5TGtuP95r7o2IhhN
AEyh209jIhMO0w8tHVN41td15YRmuOxL6boNQ17zfmqh1YAgg4VjUe7uDDI1
JsGyDFQ.BbXRiWgmjQWDGFVgeMy7bCyrRpiuj+QwprmzunxJClvTxUhrOHkW
I1nbETYrrfMoUGIM6SFPuzP6WjaCOOiucWnjKpdARqCQZV5SweLM+BKTzJC.
GCFqrMcY2aUFuK2bUc0IiyXMO4KV4AZLWDU9xp46ecXbfzi3IKBzl+QBiph6
.g7cX5nyLwngXdRiAPMuks5w7Tuld1UugRNNQESnWIH2Uz3Ca+EKLh450IVI
TgmcFDBBLQlgzQlQcOOjfZFRH9siIvaClveYWhL.tnu6UqgV+fE1ARfTeqeT
Yt578cBUmEmv.8xBHrFmftWttCEe2ApWa4A8QN8vPqmvBzWuZI4xUenn6Npr
iy+v.8CcN3wUabgjQVTy8iAw5FqvsfUvaCVoIjNQgd4DlhzffN5Ji4CFzEWC
ZgqAcv0kloXOQkWjS+nhVwe4V6MJQt6q3se2qg..3cuSsnC.78RORpuctNOR
4dtK7H44cwdjHd2cauzcghLKfxwpG4rKp83vVaipC9kwtXCNB6tud+9OKrbo
TrqE37VjOd769fSFCTy1eXvKOB.21QI7HhRxcxkFrg2rdjbGOhnzfs6RMv00
YikG+nJ6dJaL3U.NjgYicbaZpTs0Rv2ZJVMeynVZ79jkE7ZgKTqpztbCGYhn
C6Z8sGEkmbgwIqLoAnedDlNRiT6B2JVsKVpnmiRt5j9XjbDOZwOZla.SC2f6
I2nVJ2B1E2fg.sadWlimO5XTDPk9nIwV0lx52lFtB0WtJm8mDpPsQi9oovlR
pvafR3ogJX0TeZgJPmypAxPl3HXJ0sbsN8ulRZuWxQuoTNp7zg5qbraDzXNB
gtUMGw9RGPsM0szGau40FLwlXGlM3UuYRqccg7AKR7qsJ6dqlaxj47frrDwh
8YlURKmI6AkwsMgwKBBOIMYMkPtGNRbCrh.eTR1qiS19kVK+wgTf0weDJR0e
2YYRfL8dFnP811oTlQGsb4CLYm6.mVaywUi8gV.87P4KQhnKiCM42+sV.Gej
OABYtDFf54gdr4gvzJioF5H4TtPosTFM26P8lxSGTwdvFd4lnr6Z4lVGtWrx
od8fsdiwPsTRQrdy50YoR3Qh.oxcXgHR8GjEBP7rdSP3l3DQ1SakqI8lOH0a
3gp.xk5TshsmUIkZxLIB65fNMGJTJZvE7B0RAuPW.bVcmHk1EBOy5Un144t3
WDNuvSxuNxsdTpJZVX2rKpA1kYOZZO2dWSXeTqtlJnlR9XzvCvopSERKCQvG
8xsohiJseniezp2v8D.D.vLBrSugkkFEII294OGGuUKHbnLOe0+bgdTL.OZd
0NmwdCs2wnY0VjfbSWRfHC2NkNdlosVj8eQv+3kYkR8INLUbxXPc2RmqL7MX
lBwsXl9+4kgGQMoMFR9VY3+VY3+VY3mrxvmYsvZcuxrb+p7EjB0NHyy5tuoL
7WPwIPnaSt26Jqx5EqsdE7JKXiKxzrV9tNkirigPp9M5hSsLjc2KeyOJCiYD
JWpo9wPWRc7gvNuFTa3C7tiOhqtOMxgFrpoFplE39Xa0VQ2uM.SmlVwqWq2t
zUZbkiOMZZAtbSK2uVpzdOA.o9gduDEffq2UUyc+uBK49HfUEKNMxnEbr5Pg
wbcMCMXe9JkCUqMgTHiDM78ygDZOgjVV8F1wp2fqUCZRpQJruEhDglvxR.g8
jJftSIU31Wp3rkWhZZDSrYoceTtOZHRkVGriKp4YmJFiMZLFjY7k70BqoUK6
SIAg0K87DW+o9SZrac8mP8tz1Sn4FsuJkvIjH7uZf3OIEhqsyV0+RGvZ4gUG
vPwZwxCPDrqDG5abW31PKoS.C9XWMhm5J4SXgzFqqb9d9SdUddQQxuqU9BJX
vYAFSGdgwPinv9WUYo+BE0tt4smSCRZSQdF1ICcDE0xsiKeHWmn1k54L.Isp
TMA5a0suUpy61H6mhp3kW+iwpJd+osHdmVQMf57SioXbeqnF9FVPsqsMALGR
Sooe4V.hPnWTKCfH20VFPUNhUhfv3MV+2e5W9GWmqDCvvvNjSAFHfN7izp+z
Wg+D9tvfk7iosZf9GLbrpghQ0RWEcvtGbsmZwcqmRu9dB85.DHndc37NqbmL
4UL9Poy2td4xA1cLWeszapCXvWPk0QiGNohleu3BazEfe6+OmwkDpH9BbHlO
phOJhAdYLWFgucIzPSBUywjAbNcuU4PTs8TgqzN3skOoJWyIYY.AMAagn4fU
Q547eT24tMOmYmX0jo8krgd8frortnapGSue.n4bkjSp5ec3Vpl0gKlZQt8A
j6lZM0RAioNPVskn8ZYtqDkOA.agtc6htOnAfcbImz4wzh5CUat5B.vMfQpb
MiknuO5oGyWwkyg838vFg2CobdxNic2zagWMKvik1BrW9D86Rs2EPzETG6Aq
UUzhywPsotK7Q0qoRyFp6XQFAgIDWoiEB1EYZ54GsJ6jrMVWFCEEeZvS47d8
4FaCOneOXd2QPQEQ5ihp+X7lXWsdYwRERcOPaxl5ycszcuLkwGOLRW7aBS66
a5ZkE8YEcxH7dXC1Dt4EfwptcpUqQVmRbSPlmz3lJB9jF17jl0rdiZ1dSZdZ
CZpyPeaMl4C+wC+O.sS3OtB
-----------end_max5_patcher-----------
</code></pre>
