### PR TITLE
Faster pitch init

### DIFF
--- a/include/algorithms/public/CepstrumF0.hpp
+++ b/include/algorithms/public/CepstrumF0.hpp
@@ -32,8 +32,11 @@ public:
 
   void init(index size)
   {
-    // avoid allocation of maxSize^2 at constructor
-    mDCT = DCT(size, size);
+    // avoid allocation of maxSize^2 at constructor, but don't reallocate if not needed
+    
+    if (mDCT.maxOutputSize() < size || mDCT.maxInputSize() < size)
+      mDCT = DCT(size, size);
+      
     mDCT.init(size, size);
 
     mCepstrum = mCepstrumStorage.segment(0, size);

--- a/include/algorithms/public/DCT.hpp
+++ b/include/algorithms/public/DCT.hpp
@@ -28,6 +28,8 @@ public:
   using MatrixXd = Eigen::MatrixXd;
 
   DCT(index maxInputSize, index maxOutputSize)
+  : mMaxInputSize(maxInputSize)
+  , mMaxOutputSize(maxOutputSize)
   {
     mTableStorage = MatrixXd::Zero(maxOutputSize, maxInputSize);
   }
@@ -36,6 +38,11 @@ public:
   {
     using namespace std;
     assert(inputSize >= outputSize);
+    assert(inputSize <= mMaxInputSize);
+    assert(outputSize <= mMaxOutputSize);
+    // Exit if already initialised
+    if (mInputSize == inputSize && mOutputSize == outputSize)
+      return;
     mInputSize = inputSize;
     mOutputSize = outputSize;
     mTable = mTableStorage.block(0, 0, mOutputSize, mInputSize);
@@ -61,8 +68,14 @@ public:
   {
     output = (mTable * input.matrix()).array();
   }
-  index    mInputSize{40};
-  index    mOutputSize{13};
+    
+  index maxInputSize() const { return mMaxInputSize; }
+  index maxOutputSize() const { return mMaxOutputSize; }
+    
+  index    mInputSize{0};
+  index    mOutputSize{0};
+  index    mMaxInputSize{0};
+  index    mMaxOutputSize{0};
   MatrixXd mTable;
   MatrixXd mTableStorage;
 };

--- a/include/clients/rt/PitchClient.hpp
+++ b/include/clients/rt/PitchClient.hpp
@@ -150,7 +150,7 @@ public:
     return { get<kFFT>().winSize(), get<kFFT>().hopSize() }; 
   }
 
-  void  reset()
+  void reset()
   {
     mSTFTBufferedProcess.reset();
     cepstrumF0.init(get<kFFT>().frameSize());


### PR DESCRIPTION
This PR addresses #171.

Essentially it aims not to reallocate memory or recalculate tables where these can be avoided and thus it runs a lot faster in scenarios where BufPitch is being bombarded with small files and thus calling reset() and hence cepstrumF0.init() frequently.

The speed increase for my scenario (in which BufPitch is just one cog) is around 5 times faster, so this cost saving can be really *very* significant.

Hopefully the changes will be obvious - I also note that there is no mInitialised in DCT which seems a bit odd, but probably this is not 100% consistent across the codebase.