### PR TITLE
Enhance/cycling feedback

### DIFF
--- a/include/clients/rt/TransientClient.hpp
+++ b/include/clients/rt/TransientClient.hpp
@@ -39,8 +39,8 @@ enum TransientParamIndex {
 
 constexpr auto TransientParams = defineParameters(
     LongParam("order", "Order", 20, Min(10), LowerLimit<kWinSize>(),
-              UpperLimit<kBlockSize>()),
-    LongParam("blockSize", "Block Size", 256, Min(100), LowerLimit<kOrder>()),
+              UpperLimit<kBlockSize>(), Max(200)),
+    LongParam("blockSize", "Block Size", 256, Min(100), LowerLimit<kOrder>(), Max(4096)),
     LongParam("padSize", "Padding", 128, Min(0)),
     FloatParam("skew", "Skew", 0, Min(-10), Max(10)),
     FloatParam("threshFwd", "Forward Threshold", 2, Min(0)),

--- a/include/clients/rt/TransientSliceClient.hpp
+++ b/include/clients/rt/TransientSliceClient.hpp
@@ -38,8 +38,8 @@ enum TransientParamIndex {
 
 constexpr auto TransientSliceParams = defineParameters(
     LongParam("order", "Order", 20, Min(10), LowerLimit<kWinSize>(),
-              UpperLimit<kBlockSize>()),
-    LongParam("blockSize", "Block Size", 256, Min(100), LowerLimit<kOrder>()),
+              UpperLimit<kBlockSize>(), Max(200)),
+    LongParam("blockSize", "Block Size", 256, Min(100), LowerLimit<kOrder>(), Max(4096)),
     LongParam("padSize", "Padding", 128, Min(0)),
     FloatParam("skew", "Skew", 0, Min(-10), Max(10)),
     FloatParam("threshFwd", "Forward Threshold", 2, Min(0)),


### PR DESCRIPTION
Applying feedback from C74's review. 

* Upper bounds on expensive / black-holely `Transient<Slice>` parameters to stop people accidentally beach balling their machines to death