### PR TITLE
Add functions for applying constraints to param maxima

### DIFF
--- a/include/clients/nrt/FluidSharedInstanceAdaptor.hpp
+++ b/include/clients/nrt/FluidSharedInstanceAdaptor.hpp
@@ -165,6 +165,13 @@ public:
       return mParams->template applyConstraintsTo<N>(x); 
   }
 
+  template <size_t N>
+  typename ParamType<N>::type
+  applyConstraintToMax(typename ParamType<N>::type x)
+  {
+    return mParams->template applyConstraintToMax(x);
+  }
+
   template <template <size_t N, typename T> class Func, typename... Args>
   std::array<Result, sizeof...(Ts)> setMutableParameterValues(bool reportage,
                                                               Args&&... args)


### PR DESCRIPTION
Ths is to guarantee that maxima are correct, and strictly >= their params at all times, esp. in client constructors