### PR TITLE
Make `main` great again

### DIFF
--- a/.github/workflows/flucoma-core-ci.yml
+++ b/.github/workflows/flucoma-core-ci.yml
@@ -3,9 +3,9 @@ name: Flucoma Core CI
 on:
   workflow_dispatch:
   push:
-    branches: [ main, dev ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, dev ]
+    branches: [ main ]
 
 env:  
   BUILD_TYPE: Release


### PR DESCRIPTION
First change for switching over to doing our business mainly on `main`. This will trigger the core CI tests just on pushes and PRs to main (on the assumption that `dev` will go)