### PR TITLE
FluidDataSet: Remove  mutable, deal with fallout

### DIFF
--- a/include/algorithms/public/DataSetQuery.hpp
+++ b/include/algorithms/public/DataSetQuery.hpp
@@ -36,7 +36,7 @@ public:
     index  comparison;
     double value;
 
-    bool test(RealVectorView point)
+    bool test(InputRealVectorView point)
     {
       using namespace std;
       switch (comparison)
@@ -129,7 +129,7 @@ public:
 
 private:
   void addRow(
-      string id, RealVectorView point, const DataSet& current, DataSet& out)
+      string id, InputRealVectorView point, const DataSet& current, DataSet& out)
   {
     mTmpPoint.fill(0);
     index currentSize = current.pointSize();

--- a/include/algorithms/public/KNNClassifier.hpp
+++ b/include/algorithms/public/KNNClassifier.hpp
@@ -34,7 +34,7 @@ public:
                              Allocator& alloc = FluidDefaultAllocator()) const
   {
     using namespace std;
-    unordered_map<string*, double> labelsMap;
+    unordered_map<const string*, double> labelsMap;
     auto [distances, ids] = tree.kNearest(point, k, 0, alloc);
 
     double             uniformWeight = 1.0 / k;
@@ -64,11 +64,11 @@ public:
       }
     }
 
-    string* prediction;
+    const string* prediction;
     double  maxWeight = 0;
     for (size_t i = 0; i < asUnsigned(k); i++)
     {
-      string* label = labels.get(*ids[i]).data();
+      const string* label = labels.get(*ids[i]).data();
       assert(label && "KNNClassifier: ID not mapped to label");
       auto pos = labelsMap.find(label);
       if (pos == labelsMap.end())

--- a/include/clients/nrt/DataSetClient.hpp
+++ b/include/clients/nrt/DataSetClient.hpp
@@ -242,7 +242,7 @@ public:
     std::transform(
         indices.begin(), indices.begin() + nNeighbours, labels.begin(),
         [this](index i) {
-          std::string& id = mAlgorithm.getIds()[i];
+          std::string const& id = mAlgorithm.getIds()[i];
           return rt::string{id, 0, id.size(), FluidDefaultAllocator()};
         });
 

--- a/include/data/FluidDataSet.hpp
+++ b/include/data/FluidDataSet.hpp
@@ -85,11 +85,12 @@ public:
     return true;
   }
 
-  FluidTensorView<dataType, N> get(idType const& id) const
+  FluidTensorView<const dataType, N> get(idType const& id) const
   {
     auto pos = mIndex.find(id);
-    return pos != mIndex.end() ? mData.row(pos->second)
-                               : FluidTensorView<dataType, N>{nullptr, 0, 0};
+    return pos != mIndex.end()
+               ? mData.row(pos->second)
+               : FluidTensorView<const dataType, N>{nullptr, 0, 0};
   }
 
   index getIndex(idType const& id) const
@@ -127,14 +128,18 @@ public:
     return true;
   }
 
-  FluidTensorView<dataType, N + 1> getData() const { return mData; }
-  FluidTensorView<idType, 1>       getIds() const { return mIds; }
-  index                            pointSize() const { return mDim.size; }
-  index                            dims() const { return mDim.size; }
-  index                            size() const { return mIds.size(); }
-  bool                             initialized() { return (size() > 0); }
+  FluidTensorView<dataType, N + 1>       getData() { return mData; }
+  FluidTensorView<idType, 1>             getIds() { return mIds; }
+  FluidTensorView<const dataType, N + 1> getData() const { return mData; }
+  FluidTensorView<const idType, 1>       getIds() const { return mIds; }
 
-  std::string printRow(FluidTensorView<dataType, N> row, index maxCols) const
+  index pointSize() const { return mDim.size; }
+  index dims() const { return mDim.size; }
+  index size() const { return mIds.size(); }
+  bool  initialized() const { return (size() > 0); }
+
+  std::string printRow(FluidTensorView<const dataType, N> row,
+                       index                              maxCols) const
   {
     using namespace std;
     ostringstream result;
@@ -199,9 +204,9 @@ private:
     for (index i = 0; i < mIds.size(); i++) { mIndex.insert({mIds[i], i}); }
   }
 
-  mutable std::unordered_map<idType, index> mIndex;
-  mutable FluidTensor<idType, 1>            mIds;
-  mutable FluidTensor<dataType, N + 1>      mData;
-  FluidTensorSlice<N>                       mDim;
+  std::unordered_map<idType, index> mIndex;
+  FluidTensor<idType, 1>            mIds;
+  FluidTensor<dataType, N + 1>      mData;
+  FluidTensorSlice<N>               mDim;
 };
 } // namespace fluid

--- a/include/data/TensorTypes.hpp
+++ b/include/data/TensorTypes.hpp
@@ -25,6 +25,11 @@ using ComplexMatrixView = FluidTensorView<std::complex<double>, 2>;
 using RealVectorView = FluidTensorView<double, 1>;
 using ComplexVectorView = FluidTensorView<std::complex<double>, 1>;
 
+using InputRealMatrixView = FluidTensorView<const double, 2>;
+using InputComplexMatrixView = FluidTensorView<const std::complex<double>, 2>;
+using InputRealVectorView = FluidTensorView<const double, 1>;
+using InputComplexVectorView = FluidTensorView<const std::complex<double>, 1>;
+
 using ArrayXXidx = Eigen::Array<fluid::index, Eigen::Dynamic, Eigen::Dynamic>; 
 using ArrayXidx = Eigen::Array<fluid::index, Eigen::Dynamic, 1>; 
 } // namespace fluid


### PR DESCRIPTION
fixes #225

Introduces  `Input<X><Y>View>` aliases into TensorTypes.hpp for easier expression of const views