### PR TITLE
UMAP: Remove `mutable`

### DIFF
--- a/include/algorithms/public/UMAP.hpp
+++ b/include/algorithms/public/UMAP.hpp
@@ -202,7 +202,7 @@ public:
     computeEpochsPerSample(knnGraph, epochsPerSample);
     epochsPerSample = (epochsPerSample == 0).select(-1, epochsPerSample);
     optimizeLayoutAndUpdate(mEmbedding, mEmbedding, rowIndices, colIndices,
-                   epochsPerSample, true, learningRate, maxIter);
+                   epochsPerSample, learningRate, maxIter);
     DataSet out(ids, _impl::asFluid(mEmbedding));
     mInitialized = true;
     return out;
@@ -227,7 +227,7 @@ public:
     computeEpochsPerSample(knnGraph, epochsPerSample);
     epochsPerSample = (epochsPerSample == 0).select(-1, epochsPerSample);
     optimizeLayout(embedding, mEmbedding, rowIndices, colIndices,
-                   epochsPerSample, false, learningRate, maxIter);
+                   epochsPerSample, learningRate, maxIter);
     DataSet out(in.getIds(), _impl::asFluid(embedding));
     return out;
   }


### PR DESCRIPTION
`UMAP::mEmbedding` had been marked `mutable` in order to avoid some code duplication. `mutable` shouldn't be used in the absence of an accompanying lock if the principle of least astonishment is to be honoured in a multi-threaded situation. 

The problem for the original author was that a long and complex function `optimizeLayout` needs to be called both in mutating and non-mutating circumstances, and buried within nested loops is an optional update of this variable. In order for the function to be callable in a `const` case, it needed to be marked `const`, but also needed to be able to update `mEmbedding` during training. It's certainly an amount / complexity of code that one doesn't want to duplicate. 

Without more involved refactoring, I think the best we can do here is to:

* hoist the function out of the class as a function template taking the reference embedding as a template parameter (so it can be `const` or not). 
* use a compile time check on the `const`-ness of the reference embedding to enable / disable the option to update. 
* provide more clearly labelled and properly `const` (or not) member functions that delegate to the full implementation (`optimizeLayout` and `optimizeLayoutAndUpdate`). 

fixes #224