### PR TITLE
Appropriate client methods are now const

### DIFF
--- a/include/algorithms/public/Envelope.hpp
+++ b/include/algorithms/public/Envelope.hpp
@@ -59,7 +59,7 @@ public:
     return fast - slow;
   }
 
-  bool initialized() { return mInitialized; }
+  bool initialized() const { return mInitialized; }
 
 private:
   void initFilters(double cutoff)

--- a/include/algorithms/public/EnvelopeGate.hpp
+++ b/include/algorithms/public/EnvelopeGate.hpp
@@ -173,8 +173,8 @@ public:
 
     return result;
   }
-  index getLatency() { return mLatency; }
-  bool  initialized() { return mInitialized; }
+  index getLatency() const { return mLatency; }
+  bool  initialized() const { return mInitialized; }
 
 
 private:

--- a/include/algorithms/public/EnvelopeSegmentation.hpp
+++ b/include/algorithms/public/EnvelopeSegmentation.hpp
@@ -59,7 +59,7 @@ public:
     return detected;
   }
 
-  bool initialized() { return mEnvelope.initialized(); }
+  bool initialized() const { return mEnvelope.initialized(); }
 
 private:
   Envelope mEnvelope;

--- a/include/algorithms/public/HPSS.hpp
+++ b/include/algorithms/public/HPSS.hpp
@@ -151,7 +151,7 @@ public:
     _impl::asEigen<Array>(out).col(2) = buf.col(0) * residualMask.min(1.0);
   }
   
-  bool initialized() { return mInitialized; }
+  bool initialized() const { return mInitialized; }
 
 private:
   ArrayXMap makeThreshold(index nBins, double x1, double y1, double x2,

--- a/include/algorithms/public/NMFMorph.hpp
+++ b/include/algorithms/public/NMFMorph.hpp
@@ -100,7 +100,7 @@ public:
     mInitialized = true;
   }
 
-  bool initialized() { return mInitialized; }
+  bool initialized() const { return mInitialized; }
 
   void processFrame(ComplexVectorView v, double interpolation, Allocator& alloc)
   {

--- a/include/algorithms/public/SineExtraction.hpp
+++ b/include/algorithms/public/SineExtraction.hpp
@@ -145,7 +145,7 @@ public:
 
   void reset() { mCurrentFrame = 0; }
 
-  bool initialized() { return mInitialized; }
+  bool initialized() const { return mInitialized; }
 
 private:
   void computeWindowTransform(index windowSize, index transformSize,

--- a/include/algorithms/public/SineFeature.hpp
+++ b/include/algorithms/public/SineFeature.hpp
@@ -77,7 +77,7 @@ public:
     return maxNumOut;
   }
 
-  bool initialized() { return mInitialized; }
+  bool initialized() const { return mInitialized; }
 
 private:
   PeakDetection mPeakDetection;

--- a/include/algorithms/public/TransientExtraction.hpp
+++ b/include/algorithms/public/TransientExtraction.hpp
@@ -135,7 +135,7 @@ public:
     interpolate(transients.data(), residual.data(), alloc);
   }
 
-  bool initialized() { return mInitialized; }
+  bool initialized() const { return mInitialized; }
 
 private:
   void frame(const double* input, index inSize)

--- a/include/algorithms/util/MedianFilter.hpp
+++ b/include/algorithms/util/MedianFilter.hpp
@@ -57,7 +57,7 @@ public:
 
   index size() { return asSigned(mFilterSize); }
 
-  bool initialized() { return mInitialized; }
+  bool initialized() const { return mInitialized; }
 
 private:
   std::size_t mFilterSize{0};

--- a/include/clients/common/FluidBaseClient.hpp
+++ b/include/clients/common/FluidBaseClient.hpp
@@ -56,12 +56,12 @@ public:
   double sampleRate() const noexcept { return mSampleRate; };
   void   sampleRate(double sr) { mSampleRate = sr; }
 
-  const char* getInputLabel(index i)
+  const char* getInputLabel(index i) const
   {
     return i < asSigned(mInputLabels.size()) ? mInputLabels[asUnsigned(i)] : "";
   }
 
-  const char* getOutputLabel(index i)
+  const char* getOutputLabel(index i) const
   {
     return i < asSigned(mOutputLabels.size()) ? mOutputLabels[asUnsigned(i)] : "";
   }
@@ -216,7 +216,7 @@ public:
     mParams.template set(std::forward<T>(x), reportage);
   }
 
-  auto latency() { return mClient.latency(); }
+  auto latency() const { return mClient.latency(); }
 
   index audioChannelsIn() const noexcept { return mClient.audioChannelsIn(); }
   index audioChannelsOut() const noexcept { return mClient.audioChannelsOut(); }
@@ -254,12 +254,12 @@ public:
     mParams = p;
   }
 
-  const char* getInputLabel(index i)
+  const char* getInputLabel(index i) const
   {
     return mClient.getInputLabel(i);
   }
 
-  const char* getOutputLabel(index i)
+  const char* getOutputLabel(index i) const
   {
     return mClient.getOutputLabel(i);
   }

--- a/include/clients/common/ParameterSet.hpp
+++ b/include/clients/common/ParameterSet.hpp
@@ -312,9 +312,9 @@ public:
     return constrain<offset, N, kAll>(x, constraints, nullptr);
   }
 
-  template <size_t N>
-  auto applyConstraintToMax(index x) -> std::enable_if_t<
-      std::is_same_v<typename ParamType<N>::type, LongRuntimeMaxParam>, index>
+  template <size_t N, typename = std::enable_if_t<
+    std::is_same_v<typename ParamType<N>::type, LongRuntimeMaxParam>, index>>
+  auto applyConstraintToMax(index x) const
   {
     const auto constraints = GetIncreasingConstraints(constraint<N>());
     if constexpr (std::tuple_size<decltype(constraints)>::value)
@@ -465,7 +465,7 @@ public:
   {} // no-op for non-shared parameter set?
 
   template <size_t N>
-  auto descriptorAt()
+  auto descriptorAt() const
   {
     return descriptor<N>();
   }

--- a/include/clients/common/ParameterSet.hpp
+++ b/include/clients/common/ParameterSet.hpp
@@ -305,7 +305,7 @@ public:
   }
 
   template <size_t N>
-  typename ParamType<N>::type applyConstraintsTo(typename ParamType<N>::type x)
+  typename ParamType<N>::type applyConstraintsTo(typename ParamType<N>::type x) const
   {
     const index offset = std::get<N>(std::make_tuple(Os...));
     auto&       constraints = constraint<N>();
@@ -570,7 +570,7 @@ private:
 
   template <size_t Offset, size_t N, ConstraintTypes C, typename T,
             typename... Constraints>
-  T constrain(T& thisParam, const std::tuple<Constraints...>& c, Result* r)
+  T constrain(T& thisParam, const std::tuple<Constraints...>& c, Result* r) const
   {
     using CT = std::tuple<Constraints...>;
     // clang < 3.7: index_sequence_for doesn't work here
@@ -592,7 +592,7 @@ private:
   template <size_t Offset, size_t N, typename T, typename Constraints,
             size_t... Is>
   T constrainImpl(T& thisParam, Constraints& c, std::index_sequence<Is...>,
-                  Result* r)
+                  Result* r) const
   {
     T res = thisParam;
     static_cast<void>(r);

--- a/include/clients/nrt/FluidSharedInstanceAdaptor.hpp
+++ b/include/clients/nrt/FluidSharedInstanceAdaptor.hpp
@@ -160,14 +160,14 @@ public:
   }
 
   template<size_t N> 
-  typename ParamType<N>::type applyConstraintsTo(typename ParamType<N>::type x)
+  typename ParamType<N>::type applyConstraintsTo(typename ParamType<N>::type x) const
   {
       return mParams->template applyConstraintsTo<N>(x); 
   }
 
   template <size_t N>
   typename ParamType<N>::type
-  applyConstraintToMax(typename ParamType<N>::type x)
+  applyConstraintToMax(typename ParamType<N>::type x) const
   {
     return mParams->template applyConstraintToMax(x);
   }

--- a/include/clients/nrt/KDTreeClient.hpp
+++ b/include/clients/nrt/KDTreeClient.hpp
@@ -180,7 +180,7 @@ public:
     controlChannelsOut({1, 1});
   }
 
-  index latency() { return 0; }
+  index latency() const { return 0; }
 
   template <typename T>
   void process(std::vector<FluidTensorView<T, 1>>& input,

--- a/include/clients/nrt/KMeansClient.hpp
+++ b/include/clients/nrt/KMeansClient.hpp
@@ -347,7 +347,7 @@ public:
     }
   }
 
-  index latency() { return 0; }
+  index latency() const { return 0; }
 };
 
 

--- a/include/clients/nrt/KNNClassifierClient.hpp
+++ b/include/clients/nrt/KNNClassifierClient.hpp
@@ -267,7 +267,7 @@ public:
     }
   }
 
-  index latency() { return 0; }
+  index latency() const { return 0; }
 };
 
 } // namespace knnclassifier

--- a/include/clients/nrt/KNNRegressorClient.hpp
+++ b/include/clients/nrt/KNNRegressorClient.hpp
@@ -269,7 +269,7 @@ public:
     }
   }
 
-  index latency() { return 0; }
+  index latency() const { return 0; }
 };
 
 } // namespace knnregressor

--- a/include/clients/nrt/MLPClassifierClient.hpp
+++ b/include/clients/nrt/MLPClassifierClient.hpp
@@ -336,7 +336,7 @@ public:
     }
   }
 
-  index latency() { return 0; }
+  index latency() const { return 0; }
 };
 
 

--- a/include/clients/nrt/MLPRegressorClient.hpp
+++ b/include/clients/nrt/MLPRegressorClient.hpp
@@ -328,7 +328,7 @@ public:
     }
   }
 
-  index latency() { return 0; }
+  index latency() const { return 0; }
 };
 
 } // namespace mlpregressor

--- a/include/clients/nrt/NormalizeClient.hpp
+++ b/include/clients/nrt/NormalizeClient.hpp
@@ -246,7 +246,7 @@ public:
     }
   }
 
-  index latency() { return 0; }
+  index latency() const { return 0; }
 };
 
 

--- a/include/clients/nrt/PCAClient.hpp
+++ b/include/clients/nrt/PCAClient.hpp
@@ -269,7 +269,7 @@ public:
     }
   }
 
-  index latency() { return 0; }
+  index latency() const { return 0; }
 };
 
 

--- a/include/clients/nrt/RobustScaleClient.hpp
+++ b/include/clients/nrt/RobustScaleClient.hpp
@@ -242,7 +242,7 @@ public:
     }
   }
 
-  index latency() { return 0; }
+  index latency() const { return 0; }
 };
 
 } // namespace robustscale

--- a/include/clients/nrt/SKMeansClient.hpp
+++ b/include/clients/nrt/SKMeansClient.hpp
@@ -345,7 +345,7 @@ public:
     }
   }
 
-  index latency() { return 0; }
+  index latency() const { return 0; }
 };
 
 

--- a/include/clients/nrt/StandardizeClient.hpp
+++ b/include/clients/nrt/StandardizeClient.hpp
@@ -238,7 +238,7 @@ public:
     }
   }
 
-  index latency() { return 0; }
+  index latency() const { return 0; }
 };
 
 

--- a/include/clients/nrt/UMAPClient.hpp
+++ b/include/clients/nrt/UMAPClient.hpp
@@ -236,7 +236,7 @@ public:
     }
   }
 
-  index latency() { return 0; }
+  index latency() const { return 0; }
 };
 
 } // namespace umap

--- a/include/clients/rt/AmpFeatureClient.hpp
+++ b/include/clients/rt/AmpFeatureClient.hpp
@@ -90,7 +90,7 @@ public:
               get<kFastRampDownTime>(), get<kSlowRampDownTime>(), hiPassFreq));
     }
   }
-  index latency() { return 0; }
+  index latency() const { return 0; }
 
   void reset(FluidContext&)
   {

--- a/include/clients/rt/AmpGateClient.hpp
+++ b/include/clients/rt/AmpGateClient.hpp
@@ -119,7 +119,7 @@ public:
                     get<kMinTimeBelowThreshold>(), get<kDownwardLookupTime>());
   }
 
-  index latency()
+  index latency() const
   {
     return std::max(
         get<kMinTimeAboveThreshold>() + get<kUpwardLookupTime>(),

--- a/include/clients/rt/AmpSliceClient.hpp
+++ b/include/clients/rt/AmpSliceClient.hpp
@@ -94,7 +94,7 @@ public:
           get<kSlowRampDownTime>(), hiPassFreq, get<kDebounce>()));
     }
   }
-  index latency() { return 0; }
+  index latency() const { return 0; }
 
   void reset(FluidContext&)
   {

--- a/include/clients/rt/AudioTransportClient.hpp
+++ b/include/clients/rt/AudioTransportClient.hpp
@@ -89,7 +89,7 @@ public:
     if (output[0].data()) output[0] <<= result;
   }
 
-  index latency() { return get<kFFT>().winSize(); }
+  index latency() const { return get<kFFT>().winSize(); }
   void  reset(FluidContext&) { mBufferedProcess.reset(); }
 
 private:

--- a/include/clients/rt/BaseSTFTClient.hpp
+++ b/include/clients/rt/BaseSTFTClient.hpp
@@ -53,7 +53,7 @@ public:
     audioChannelsOut(1);
   }
 
-  index latency() { return get<kFFT>().winSize(); }
+  index latency() const { return get<kFFT>().winSize(); }
 
   void reset(FluidContext&) { mSTFTBufferedProcess.reset(); }
 

--- a/include/clients/rt/ChromaClient.hpp
+++ b/include/clients/rt/ChromaClient.hpp
@@ -108,7 +108,7 @@ public:
     output[0](Slice(nChroma, get<kNChroma>().max() - nChroma)).fill(0);
   }
 
-  index latency() { return get<kFFT>().winSize(); }
+  index latency() const { return get<kFFT>().winSize(); }
 
   void reset(FluidContext const& c)
   {

--- a/include/clients/rt/GainClient.hpp
+++ b/include/clients/rt/GainClient.hpp
@@ -49,7 +49,7 @@ public:
     audioChannelsOut(1);
   }
 
-  index latency() { return 0; }
+  index latency() const { return 0; }
   void  reset() {}
 
   template <typename T>

--- a/include/clients/rt/HPSSClient.hpp
+++ b/include/clients/rt/HPSSClient.hpp
@@ -77,7 +77,7 @@ public:
     FluidBaseClient::setOutputLabels({"harmonic component", "percussive component", "residual (in modes 1 & 2)"});
   }
 
-  index latency()
+  index latency() const
   {
     return ((get<kHSize>() - 1) * get<kFFT>().hopSize()) +
            get<kFFT>().winSize();

--- a/include/clients/rt/LoudnessClient.hpp
+++ b/include/clients/rt/LoudnessClient.hpp
@@ -116,7 +116,7 @@ public:
     output[0](Slice(numOuts, mMaxFeatures - numOuts)).fill(0);
   }
 
-  index latency() { return get<kWindowSize>(); }
+  index latency() const { return get<kWindowSize>(); }
 
   void reset(FluidContext& c)
   {

--- a/include/clients/rt/MFCCClient.hpp
+++ b/include/clients/rt/MFCCClient.hpp
@@ -130,7 +130,7 @@ public:
       output[0](Slice(nCoefs, get<kNCoefs>().max() - nCoefs)).fill(0);
   }
 
-  index latency() { return get<kFFT>().winSize(); }
+  index latency() const { return get<kFFT>().winSize(); }
 
   void reset(FluidContext& c)
   {

--- a/include/clients/rt/MelBandsClient.hpp
+++ b/include/clients/rt/MelBandsClient.hpp
@@ -118,7 +118,7 @@ public:
     output[0](Slice(nBands, get<kNBands>().max() - nBands)).fill(0);
   }
 
-  index latency() { return get<kFFT>().winSize(); }
+  index latency() const { return get<kFFT>().winSize(); }
 
   void reset(FluidContext& c)
   {

--- a/include/clients/rt/NMFFilterClient.hpp
+++ b/include/clients/rt/NMFFilterClient.hpp
@@ -60,7 +60,7 @@ public:
     setOutputLabels({"filtered input"});
   }
 
-  index latency() { return get<kFFT>().winSize(); }
+  index latency() const { return get<kFFT>().winSize(); }
 
   void reset(FluidContext&) { mSTFTProcessor.reset(); }
 

--- a/include/clients/rt/NMFMatchClient.hpp
+++ b/include/clients/rt/NMFMatchClient.hpp
@@ -66,7 +66,7 @@ public:
     setOutputLabels({"activation amount for each component"});
   }
 
-  index latency() { return get<kFFT>().winSize(); }
+  index latency() const { return get<kFFT>().winSize(); }
 
   void reset(FluidContext&) { mSTFTProcessor.reset(); }
 

--- a/include/clients/rt/NMFMorphClient.hpp
+++ b/include/clients/rt/NMFMorphClient.hpp
@@ -69,7 +69,7 @@ public:
     setOutputLabels({"morphed signal"});
   }
 
-  index latency() { return get<kFFT>().winSize(); }
+  index latency() const { return get<kFFT>().winSize(); }
 
   void reset(FluidContext&) { mSTFTProcessor.reset(); }
 

--- a/include/clients/rt/NoInputSTFTClient.hpp
+++ b/include/clients/rt/NoInputSTFTClient.hpp
@@ -39,7 +39,7 @@ public:
     audioChannelsOut(1);
   }
 
-  index latency() { return params.fftSettings.winSize(); }
+  index latency() const { return params.fftSettings.winSize(); }
 
   void reset(FluidContext&) { mSTFTBufferedProcess.reset(); }
 

--- a/include/clients/rt/NoveltyFeatureClient.hpp
+++ b/include/clients/rt/NoveltyFeatureClient.hpp
@@ -181,7 +181,7 @@ public:
     output[0](0) = static_cast<T>(mDescriptor);
   }
 
-  index latency()
+  index latency() const
   {
     index filterSize = get<kFilterSize>();
     if (filterSize % 2) filterSize++;

--- a/include/clients/rt/NoveltySliceClient.hpp
+++ b/include/clients/rt/NoveltySliceClient.hpp
@@ -200,7 +200,7 @@ public:
     output[0] <<= out.row(0);
   }
 
-  index latency()
+  index latency() const
   {
     index filterSize = get<kFilterSize>();
     if (filterSize % 2) filterSize++;

--- a/include/clients/rt/OnsetFeatureClient.hpp
+++ b/include/clients/rt/OnsetFeatureClient.hpp
@@ -106,7 +106,7 @@ public:
     output[0](0) = static_cast<T>(mDescriptor);
   }
 
-  index latency() { return static_cast<index>(get<kFFT>().hopSize()); }
+  index latency() const { return static_cast<index>(get<kFFT>().hopSize()); }
 
   AnalysisSize analysisSettings()
   {

--- a/include/clients/rt/OnsetSliceClient.hpp
+++ b/include/clients/rt/OnsetSliceClient.hpp
@@ -125,7 +125,7 @@ public:
     output[0]<<= out.row(0);
   }
 
-  index latency() { return static_cast<index>(get<kFFT>().hopSize()); }
+  index latency() const { return static_cast<index>(get<kFFT>().hopSize()); }
 
   void reset(FluidContext& c)
   {    

--- a/include/clients/rt/PitchClient.hpp
+++ b/include/clients/rt/PitchClient.hpp
@@ -147,7 +147,7 @@ public:
       
     output[0](Slice(numOuts,mMaxFeatures - numOuts)).fill(0);         
   }
-  index latency() { return get<kFFT>().winSize(); }
+  index latency() const { return get<kFFT>().winSize(); }
 
   AnalysisSize analysisSettings()
   {

--- a/include/clients/rt/RunningStatsClient.hpp
+++ b/include/clients/rt/RunningStatsClient.hpp
@@ -87,7 +87,7 @@ public:
     return defineMessages(makeMessage("clear", &RunningStatsClient::clear));
   }
 
-  index latency() { return 0; }
+  index latency() const { return 0; }
 
 private:
   algorithm::RunningStats mAlgorithm;

--- a/include/clients/rt/SineFeatureClient.hpp
+++ b/include/clients/rt/SineFeatureClient.hpp
@@ -145,7 +145,7 @@ public:
     }
   }
 
-  index latency() { return get<kFFT>().winSize(); }
+  index latency() const { return get<kFFT>().winSize(); }
   
   void  reset(FluidContext&)
   {

--- a/include/clients/rt/SinesClient.hpp
+++ b/include/clients/rt/SinesClient.hpp
@@ -114,7 +114,7 @@ public:
         });
   }
 
-  index latency()
+  index latency() const
   {
     return get<kFFT>().winSize() +
            (get<kFFT>().hopSize() * get<kMinTrackLen>());

--- a/include/clients/rt/SpectralShapeClient.hpp
+++ b/include/clients/rt/SpectralShapeClient.hpp
@@ -126,7 +126,7 @@ public:
     output[0](Slice(numOuts, mMaxOutputSize - numOuts)).fill(0);
   }
 
-  index latency() { return get<kFFT>().winSize(); }
+  index latency() const { return get<kFFT>().winSize(); }
 
   void reset(FluidContext&) { mSTFTBufferedProcess.reset(); }
 

--- a/include/clients/rt/TransientClient.hpp
+++ b/include/clients/rt/TransientClient.hpp
@@ -128,7 +128,7 @@ public:
     if (output[1].data()) output[1] <<= out.row(1);
   }
 
-  index latency()
+  index latency() const
   {
     return get<kPadding>() + get<kBlockSize>() - get<kOrder>();
   }

--- a/include/clients/rt/TransientSliceClient.hpp
+++ b/include/clients/rt/TransientSliceClient.hpp
@@ -129,7 +129,7 @@ public:
     if (output[0].data()) output[0] <<= out.row(0);
   }
 
-  index latency()
+  index latency() const
   {
     return get<kPadding>() + get<kBlockSize>() - get<kOrder>();
   }


### PR DESCRIPTION
This is desirable as it allows differentiation outside of the client / parameter set of what will touch object state (which applying constraints does not).

This will aid in reasoning about threading things in other places.