### PR TITLE
Avoid re-making the DCT table if it is already correct when initialising

### DIFF
--- a/include/algorithms/public/DCT.hpp
+++ b/include/algorithms/public/DCT.hpp
@@ -41,6 +41,11 @@ public:
     assert(inputSize <= mTable.cols());
     assert(outputSize <= mTable.rows());
 
+    // Do not reinitialise if there is no need
+      
+    if (mInitialized && mInputSize == inputSize && mOutputSize == outputSize)
+      return;
+      
     mInputSize = inputSize;
     mOutputSize = outputSize;
     mTable.setZero();


### PR DESCRIPTION
This PR is the one remaining change from #172 that was not effectively integrated.

I will need to find a patch that demonstrates the speed issue to see if this is a worthwhile optimisation, but it also needs checking for anything that uses DCT. The behaviour to check is that around anything that causes an object to have init() called (so does the object produce the correct results on a second analysis for example)