### PR TITLE
Adapt YINFFT to store its FFT, rather than allocating per frame (usin…

### DIFF
--- a/examples/describe.cpp
+++ b/examples/describe.cpp
@@ -91,7 +91,7 @@ int main(int argc, char* argv[])
   STFT          stft{windowSize, fftSize, hopSize};
   MelBands      bands{nBands, fftSize};
   DCT           dct{nBands, nCoefs};
-  YINFFT        yin;
+  YINFFT        yin{nBins, FluidDefaultAllocator()};
   SpectralShape shape(FluidDefaultAllocator());
   Loudness      loudness{windowSize};
   MultiStats    stats;

--- a/include/algorithms/public/YINFFT.hpp
+++ b/include/algorithms/public/YINFFT.hpp
@@ -43,6 +43,8 @@ public:
     index  nBins = input.size();
     double squareMagSum = 2 * squareMag.sum();
 
+    mFFT.resize(2 * (nBins - 1));
+      
     ScopedEigenMap<ArrayXd> squareMagSym(2 * (nBins - 1), alloc);
     squareMagSym << squareMag[0], squareMag.segment(1, nBins - 1),
         squareMag.segment(1, nBins - 2).reverse();

--- a/include/algorithms/public/YINFFT.hpp
+++ b/include/algorithms/public/YINFFT.hpp
@@ -26,7 +26,7 @@ class YINFFT
 
 public:
     
-  YINFFT(index maxInputSize, Allocator& alloc)
+  YINFFT(index maxInputSize, Allocator& alloc = FluidDefaultAllocator())
   : mFFT(2 * maxInputSize - 1, alloc)
   {}
   

--- a/include/clients/rt/NoveltyFeatureClient.hpp
+++ b/include/clients/rt/NoveltyFeatureClient.hpp
@@ -79,6 +79,7 @@ public:
         mMelBands{40, get<kFFT>().max(), c.allocator()},
         mDCT{40, 13, c.allocator()},
         mChroma{12, get<kFFT>().max(), c.allocator()},
+        mYinFFT(get<kFFT>().maxFrameSize(), c.allocator()),
         mLoudness{get<kFFT>().max(), c.allocator()}
   {
     audioChannelsIn(1);

--- a/include/clients/rt/NoveltySliceClient.hpp
+++ b/include/clients/rt/NoveltySliceClient.hpp
@@ -89,8 +89,8 @@ public:
                                                               c.allocator()},
         mChroma{12, get<kFFT>().max(), c.allocator()}, mLoudness{
                                                            get<kFFT>().max(),
-                                                           c.allocator()}
-
+                                                           c.allocator()},
+        mYinFFT(get<kFFT>().maxFrameSize(), c.allocator())
   {
     audioChannelsIn(1);
     audioChannelsOut(1);

--- a/include/clients/rt/PitchClient.hpp
+++ b/include/clients/rt/PitchClient.hpp
@@ -78,7 +78,8 @@ public:
 
   PitchClient(ParamSetViewType& p, FluidContext& c)
       : mParams(p), mSTFTBufferedProcess(get<kFFT>(), 1, 0, c.hostVectorSize(), c.allocator()),
-        cepstrumF0(get<kFFT>().maxFrameSize(), c.allocator()),
+        mCepstrumF0(get<kFFT>().maxFrameSize(), c.allocator()),
+        mYinFFT(get<kFFT>().maxFrameSize(), c.allocator()),
         mMagnitude(get<kFFT>().maxFrameSize(), c.allocator()),
         mDescriptors(2, c.allocator())
   {
@@ -99,7 +100,7 @@ public:
 
     if (mParamTracker.changed(get<kFFT>().frameSize(), sampleRate(), c.hostVectorSize()))
     {
-      cepstrumF0.init(get<kFFT>().frameSize(), c.allocator());
+      mCepstrumF0.init(get<kFFT>().frameSize(), c.allocator());
       mSTFTBufferedProcess = STFTBufferedProcess(get<kFFT>(), 1, 0, c.hostVectorSize(), c.allocator());
 //      mMagnitude.resize(get<kFFT>().frameSize());
     }
@@ -112,15 +113,15 @@ public:
           switch (get<kAlgorithm>())
           {
           case 0:
-            cepstrumF0.processFrame(mags, mDescriptors, get<kMinFreq>(),
+            mCepstrumF0.processFrame(mags, mDescriptors, get<kMinFreq>(),
                                     get<kMaxFreq>(), sampleRate(),c.allocator());
             break;
           case 1:
-            hps.processFrame(mags, mDescriptors, 4, get<kMinFreq>(),
+            mHPS.processFrame(mags, mDescriptors, 4, get<kMinFreq>(),
                              get<kMaxFreq>(), sampleRate(), c.allocator());
             break;
           case 2:
-            yinFFT.processFrame(mags, mDescriptors, get<kMinFreq>(),
+            mYinFFT.processFrame(mags, mDescriptors, get<kMinFreq>(),
                                 get<kMaxFreq>(), sampleRate(), c.allocator());
             break;
           }
@@ -157,7 +158,7 @@ public:
   void  reset(FluidContext& c)
   {
     mSTFTBufferedProcess.reset();
-    cepstrumF0.init(get<kFFT>().frameSize(), c.allocator());
+    mCepstrumF0.init(get<kFFT>().frameSize(), c.allocator());
 //    mMagnitude.resize(get<kFFT>().frameSize());
   }
 
@@ -166,9 +167,9 @@ private:
   
   STFTBufferedProcess<> mSTFTBufferedProcess;
 
-  CepstrumF0             cepstrumF0;
-  HPS                    hps;
-  YINFFT                 yinFFT;
+  CepstrumF0             mCepstrumF0;
+  HPS                    mHPS;
+  YINFFT                 mYinFFT;
   FluidTensor<double, 1> mMagnitude;
   FluidTensor<double, 1> mDescriptors;
 };

--- a/tests/algorithms/public/TestNoveltySegmentation.cpp
+++ b/tests/algorithms/public/TestNoveltySegmentation.cpp
@@ -144,7 +144,7 @@ NoveltyPitchTest(fluid::FluidTensorView<const double, 1> testSignal, Params p)
   FluidTensor<double, 1>               pitchFrame(2);
 
   auto stft = STFT{p.window, p.fft, p.hop};
-  auto pitch = fluid::algorithm::YINFFT();
+  auto pitch = fluid::algorithm::YINFFT((p.fft / 2) + 1);
 
   auto makeInput = [&stft, &pitch, &stftFrame, &magnitudes,
                     &pitchFrame](auto source) {


### PR DESCRIPTION
…g the default allocator)

This is an update for #169.

This is not only a speed optimisation. It also fixes the fact that even in SC it will currently allocate an FFT using the default allocator for every frame whoever yinFFT is called.

I will check the tests, which failed last time and make any necessary updates as a second step.