### PR TITLE
Add a mechanism for communicating streaming size behaviour at compile…

### DIFF
--- a/include/clients/common/AudioClient.hpp
+++ b/include/clients/common/AudioClient.hpp
@@ -34,12 +34,17 @@ constexpr bool isAudio = isAudioIn<T> || isAudioOut<T>;
 struct Control
 {};
 struct ControlIn : Control 
-{}; 
+{};
 struct ControlOut : Control
 {};
+struct ControlOutFollowsIn : ControlIn, ControlOut
+{};
+
 
 template <typename T>
 constexpr bool isControlIn = std::is_base_of<ControlIn, T>::value;
+template <typename T>
+constexpr bool isControlOutFollowsIn = std::is_base_of<ControlOutFollowsIn, T>::value;
 template <typename T>
 constexpr bool isControlOut = std::is_base_of<ControlOut, T>::value;
 template <typename T>

--- a/include/clients/rt/RunningStatsClient.hpp
+++ b/include/clients/rt/RunningStatsClient.hpp
@@ -29,7 +29,7 @@ using HostVector = FluidTensorView<T, 1>;
 constexpr auto RunningStatsParams =
     defineParameters(LongParam("history", "History Size", 2, Min(2)));
 
-class RunningStatsClient : public FluidBaseClient, public ControlIn, ControlOut
+class RunningStatsClient : public FluidBaseClient, public ControlOutFollowsIn
 {
 public:
   using ParamDescType = decltype(RunningStatsParams);


### PR DESCRIPTION
… time

This is part of a fix for the max (and other) wrappers that is needed so that wrappers can be aware of how IO sizes will be managed at compile time (and consequently without the need to instantiate a client - as in the main() of the max wrapper or the equivalent class definition section of the pd wrapper).

As this involves hierarchical inheritance this change should not affect the current behaviour of the wrappers in any way until modifications are made to them also.