### PR TITLE
compiling examples readme guide

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,31 @@
+# Compiling examples
+
+## Bulletproof configuration
+
+```sh
+# in flucoma-core root directory, create a build directory and cd into it
+mkdir build && cd build
+
+# CMake to configure targets
+cmake .. -DBUILD_EXAXMPLES=ON
+
+# build example target, currently only `describe`
+cmake --build . --target describe
+#    OR
+make describe
+```
+
+## Linking local repos
+
+```sh
+# in flucoma-core root directory, create a build directory and cd into it
+mkdir build && cd build
+
+# CMake to configure targets
+cmake .. -DBUILD_EXAXMPLES=ON -C/path/to/cache/file.cmake
+
+# build example target, currently only `describe`
+cmake --build . --target describe
+#    OR
+make describe
+```

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,18 +14,3 @@ cmake --build . --target describe
 #    OR
 make describe
 ```
-
-## Linking local repos
-
-```sh
-# in flucoma-core root directory, create a build directory and cd into it
-mkdir build && cd build
-
-# CMake to configure targets
-cmake .. -DBUILD_EXAXMPLES=ON -C/path/to/cache/file.cmake
-
-# build example target, currently only `describe`
-cmake --build . --target describe
-#    OR
-make describe
-```


### PR DESCRIPTION
@AlexHarker 
the instruction to avoid #233 and compile examples to find the dependencies properly
guidance to compile examples with local versions of dependencies using the `cmake` cache file path for development is quite vague, perhaps an example initial cache file might be useful ?