### PR TITLE
fixes non-initialisation for NRT version of AmpGate.

### DIFF
--- a/include/clients/rt/AmpGateClient.hpp
+++ b/include/clients/rt/AmpGateClient.hpp
@@ -161,6 +161,7 @@ struct NRTAmpGate
     std::vector<HostVectorView> output{binaryOut.row(0)};
 
     // convert binary to spikes
+    client.reset(c);
     client.process(input, output, c);
 
     // add onset at start if needed


### PR DESCRIPTION
This seems to fix the filter having memories between calls. @weefuzzy I just have 2 very quick questions for you:

- is the NRT adaptor running init on all those automagically converted? I don't know where to look so any pointers welcome.
- is the way I do it in this PR for that object which has its own magic adaptor the right way?

Thanks for your help