### PR TITLE
fix #259 init debounce counter

### DIFF
--- a/include/algorithms/public/EnvelopeSegmentation.hpp
+++ b/include/algorithms/public/EnvelopeSegmentation.hpp
@@ -28,7 +28,7 @@ public:
   void init(double floor, double hiPassFreq)
   {
     mEnvelope.init(floor,hiPassFreq);
-    mDebounceCount = 1;
+    mDebounceCount = 0;
     mPrevValue = 0;
     mState = false;
   }
@@ -63,7 +63,7 @@ public:
 
 private:
   Envelope mEnvelope;
-  index  mDebounceCount{1};
+  index  mDebounceCount{0};
   double mPrevValue{0};
   bool   mState{false};
 };

--- a/include/algorithms/public/NoveltySegmentation.hpp
+++ b/include/algorithms/public/NoveltySegmentation.hpp
@@ -36,7 +36,7 @@ public:
       Allocator& alloc = FluidDefaultAllocator())
   {
     mNovelty.init(kernelSize, filterSize, nDims, alloc);
-    mDebounceCount = 1;
+    mDebounceCount = 0;
     mPeakBuffer.setZero();
   }
 
@@ -64,7 +64,7 @@ public:
 private:
   NoveltyFeature          mNovelty;
   ScopedEigenMap<ArrayXd> mPeakBuffer;
-  index                   mDebounceCount{1};
+  index                   mDebounceCount{0};
 };
 } // namespace algorithm
 } // namespace fluid

--- a/include/algorithms/public/OnsetSegmentation.hpp
+++ b/include/algorithms/public/OnsetSegmentation.hpp
@@ -38,7 +38,7 @@ public:
   void init(index windowSize, index fftSize, index filterSize)
   {
     mODF.init(windowSize, fftSize, filterSize);
-    mDebounceCount = 1;
+    mDebounceCount = 0;
   }
 
   /// input window isn't necessarily a single framre because it should encompass
@@ -66,7 +66,7 @@ public:
   }
 
 private:
-  index                   mDebounceCount{1};
+  index                   mDebounceCount{0};
   OnsetDetectionFunctions mODF;
   double                  mPrevFuncVal{0.0};
 };


### PR DESCRIPTION
Fixes #259 by setting the init of the debounce counter in the 3 slicers that had it to 0 instead of 1. when 1, the condition when the (infinite state of 0 input) to (any signal) which should correctly trigger an attack at frame 0 was ignored, which is a conceptual error compare to our RT one.

Conceptually, we always assumed silence padding as it is what happens in the CCE in RT to these inputs. It is the less worse option. that counter was starting at 1 and dismissing signal at input.

see the bug report to have a comparison patch. or just approve :)

thanks