### PR TITLE
Update flucoma-core for hisstools header-only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ FetchContent_Declare(
   HISSTools
   GIT_REPOSITORY https://github.com/AlexHarker/HISSTools_Library
   GIT_PROGRESS TRUE
-  GIT_TAG 447421d
+  GIT_TAG f3292ad 
 )
 
 FetchContent_Declare(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ FetchContent_Declare(
   HISSTools
   GIT_REPOSITORY https://github.com/AlexHarker/HISSTools_Library
   GIT_PROGRESS TRUE
-  GIT_TAG ce4c7f6
+  GIT_TAG e2d8083
 )
 
 FetchContent_Declare(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ FetchContent_Declare(
   HISSTools
   GIT_REPOSITORY https://github.com/AlexHarker/HISSTools_Library
   GIT_PROGRESS TRUE
-  GIT_TAG e5091cf
+  GIT_TAG ce4c7f6
 )
 
 FetchContent_Declare(
@@ -168,21 +168,6 @@ if(NOT fmt_POPULATED)
 endif()
 add_subdirectory(${fmt_SOURCE_DIR} ${fmt_BINARY_DIR} EXCLUDE_FROM_ALL)
 
-# HISSTools FFT target
-add_library(
-  HISSTools_FFT STATIC "${hisstools_SOURCE_DIR}/HISSTools_FFT/HISSTools_FFT.cpp"
-)
-
-target_link_libraries(
-  HISSTools_FFT PRIVATE ${ACCELERATE}
-)
-
-target_include_directories(HISSTools_FFT PUBLIC "${hisstools_SOURCE_DIR}")
-
-set_target_properties(HISSTools_FFT PROPERTIES
-    POSITION_INDEPENDENT_CODE ON
-)
-
 # Brute force staic runtime on windwos
 if(MSVC)
   foreach(flag_var
@@ -194,13 +179,6 @@ if(MSVC)
   endforeach()
 endif()
 
-#HISSTools Audiofile Target
-add_library(
-  HISSTools_AudioFile STATIC
-  "${hisstools_SOURCE_DIR}/AudioFile/BaseAudioFile.cpp"
-  "${hisstools_SOURCE_DIR}/AudioFile/IAudioFile.cpp"
-  "${hisstools_SOURCE_DIR}/AudioFile/OAudioFile.cpp"
-)
 
 #Fluid Decomposition header-only target
 add_library(FLUID_DECOMPOSITION INTERFACE)
@@ -212,13 +190,12 @@ target_include_directories(
   FLUID_DECOMPOSITION SYSTEM INTERFACE #we don't want warnings from Eigen or HissTools
   "${eigen_SOURCE_DIR}"
   "${spectra_SOURCE_DIR}/include"
-  "${hisstools_SOURCE_DIR}"
+  "${hisstools_SOURCE_DIR}/include"
   "${memory_SOURCE_DIR}/include/foonathan"
   "${fmt_SOURCE_DIR}/include"
 )
 target_link_libraries(
   FLUID_DECOMPOSITION INTERFACE 
-  HISSTools_FFT 
   flucoma_VERSION_LIB 
   tl::optional
   nlohmann_json::nlohmann_json
@@ -244,16 +221,12 @@ target_compile_definitions(FLUID_DECOMPOSITION INTERFACE EIGEN_MPL2_ONLY=1)
 
 if(APPLE)
   #targeting <= 10.9, need to really emphasise that we want libc++ both to compiler and linker
-  target_compile_options(HISSTools_FFT PUBLIC -stdlib=libc++)
-  target_compile_options(HISSTools_AudioFile PUBLIC -stdlib=libc++)
   target_compile_options(FLUID_DECOMPOSITION INTERFACE -stdlib=libc++)
-  target_link_libraries(FLUID_DECOMPOSITION INTERFACE -stdlib=libc++)
+  target_link_libraries(FLUID_DECOMPOSITION INTERFACE -stdlib=libc++ ${ACCELERATE})
 endif()
 
 #Apply any vector instruction flags
 if(DEFINED FLUID_ARCH)
-  target_compile_options(HISSTools_FFT PUBLIC ${FLUID_ARCH})
-  target_compile_options(HISSTools_AudioFile PUBLIC ${FLUID_ARCH})
   target_compile_options(FLUID_DECOMPOSITION INTERFACE ${FLUID_ARCH})
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ FetchContent_Declare(
   HISSTools
   GIT_REPOSITORY https://github.com/AlexHarker/HISSTools_Library
   GIT_PROGRESS TRUE
-  GIT_TAG e2d8083
+  GIT_TAG 447421d
 )
 
 FetchContent_Declare(

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -5,7 +5,7 @@ foreach (EXAMPLE  describe)
 	)
 
 	target_link_libraries(
-		${EXAMPLE} PRIVATE FLUID_DECOMPOSITION  HISSTools_AudioFile HISSTools_FFT
+		${EXAMPLE} PRIVATE FLUID_DECOMPOSITION
 	)
 
 	target_compile_options(${EXAMPLE} PRIVATE ${FLUID_ARCH})

--- a/examples/describe.cpp
+++ b/examples/describe.cpp
@@ -13,7 +13,7 @@ This program demonstrates the use of the fluid decomposition toolbox
 to compute a summary of spectral features of an audio file
 */
 
-#include <AudioFile/IAudioFile.h>
+#include <audio_file/in_file.hpp>
 #include <Eigen/Core>
 #include <algorithms/public/DCT.hpp>
 #include <algorithms/public/Loudness.hpp>
@@ -67,12 +67,12 @@ int main(int argc, char* argv[])
   }
   const char* inputFile = argv[1];
 
-  HISSTools::IAudioFile file(inputFile);
+  htl::in_audio_file file(inputFile);
 
-  index nSamples = file.getFrames();
-  auto  samplingRate = file.getSamplingRate();
+  index nSamples = file.frames();
+  auto  samplingRate = file.sampling_rate();
 
-  if (!file.isOpen())
+  if (!file.is_open())
   {
     cout << "Input file could not be opened\n";
     return -2;
@@ -102,7 +102,7 @@ int main(int argc, char* argv[])
   loudness.init(windowSize, samplingRate);
 
   RealVector in(nSamples);
-  file.readChannel(in.data(), nSamples, 0);
+  file.read_channel(in.data(), nSamples, 0);
   RealVector padded(in.size() + windowSize + hopSize);
   index      nFrames = floor((padded.size() - windowSize) / hopSize);
   RealMatrix pitchMat(nFrames, 2);

--- a/examples/describe.cpp
+++ b/examples/describe.cpp
@@ -13,7 +13,6 @@ This program demonstrates the use of the fluid decomposition toolbox
 to compute a summary of spectral features of an audio file
 */
 
-#include <audio_file/in_file.hpp>
 #include <Eigen/Core>
 #include <algorithms/public/DCT.hpp>
 #include <algorithms/public/Loudness.hpp>
@@ -22,6 +21,7 @@ to compute a summary of spectral features of an audio file
 #include <algorithms/public/STFT.hpp>
 #include <algorithms/public/SpectralShape.hpp>
 #include <algorithms/public/YINFFT.hpp>
+#include <audio_file/in_file.hpp>
 #include <data/FluidIndex.hpp>
 #include <data/FluidMemory.hpp>
 #include <data/TensorTypes.hpp>

--- a/include/algorithms/util/FFT.hpp
+++ b/include/algorithms/util/FFT.hpp
@@ -26,7 +26,7 @@ public:
   {
     assert(maxSize > 0 && "FFT Max Size must be > 0!");
     htl::create_fft_setup(&mSetup,
-                           asUnsigned(static_cast<index>(std::log2(maxSize))));
+                          asUnsigned(static_cast<index>(std::log2(maxSize))));
   }
 
   ~FFTSetup()
@@ -48,11 +48,11 @@ public:
   }
 
   htl::setup_type<double> operator()() const noexcept { return mSetup; }
-  index       maxSize() const noexcept { return mMaxSize; }
+  index                   maxSize() const noexcept { return mMaxSize; }
 
 private:
   htl::setup_type<double> mSetup{nullptr};
-  index       mMaxSize;
+  index                   mMaxSize;
 };
 } // namespace impl
 
@@ -66,8 +66,7 @@ public:
 
   FFT() = delete;
 
-  FFT(index size, Allocator& alloc = FluidDefaultAllocator())
-  noexcept
+  FFT(index size, Allocator& alloc = FluidDefaultAllocator()) noexcept
       : mMaxSize(size), mSize(size), mFrameSize(size / 2 + 1),
         mLog2Size(static_cast<index>(std::log2(size))), mSetup(getFFTSetup()),
         mRealBuffer(asUnsigned(mFrameSize), alloc),
@@ -94,8 +93,8 @@ public:
 
     mSplit.realp = mRealBuffer.data();
     mSplit.imagp = mImagBuffer.data();
-    htl::rfft(mSetup, input.derived().data(), &mSplit,
-                   asUnsigned(input.size()), asUnsigned(mLog2Size));
+    htl::rfft(mSetup, input.derived().data(), &mSplit, asUnsigned(input.size()),
+              asUnsigned(mLog2Size));
     mSplit.realp[mFrameSize - 1] = mSplit.imagp[0];
     mSplit.imagp[mFrameSize - 1] = 0;
     mSplit.imagp[0] = 0;
@@ -119,10 +118,10 @@ protected:
   index mFrameSize{513};
   index mLog2Size{10};
 
-  htl::setup_type<double>   mSetup;
-  htl::split_type<double>   mSplit;
-  rt::vector<double>        mRealBuffer;
-  rt::vector<double>        mImagBuffer;
+  htl::setup_type<double> mSetup;
+  htl::split_type<double> mSplit;
+  rt::vector<double>      mRealBuffer;
+  rt::vector<double>      mImagBuffer;
 
 private:
   rt::vector<std::complex<double>> mOutputBuffer;
@@ -150,8 +149,7 @@ public:
       mSplit.imagp[i] = input(i).imag();
     }
     mSplit.imagp[0] = mSplit.realp[mFrameSize - 1];
-    htl::rifft(mSetup, &mSplit, mOutputBuffer.data(),
-                    asUnsigned(mLog2Size));
+    htl::rifft(mSetup, &mSplit, mOutputBuffer.data(), asUnsigned(mLog2Size));
     return {mOutputBuffer.data(), mSize};
   }
 

--- a/tests/test_signals/CMakeLists.txt
+++ b/tests/test_signals/CMakeLists.txt
@@ -9,6 +9,6 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Signals.cpp.in ${CMAKE_BINARY_DIR}/Si
 add_library(TestSignals STATIC ${CMAKE_BINARY_DIR}/Signals.cpp)
 target_include_directories(TestSignals PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 target_link_libraries(TestSignals PRIVATE 
-  FLUID_DECOMPOSITION HISSTools_AudioFile
+  FLUID_DECOMPOSITION
 )
 target_compile_features(TestSignals PUBLIC cxx_std_14)

--- a/tests/test_signals/Signals.cpp.in
+++ b/tests/test_signals/Signals.cpp.in
@@ -1,5 +1,5 @@
 #include "Signals.hpp"
-#include <AudioFile/IAudioFile.h>
+#include <audio_file/in_file.hpp>
 #include <data/FluidTensor.hpp>
 #include <algorithm>
 #include <cmath>
@@ -78,19 +78,19 @@ FluidTensor<double, 1> make_smoothSine()
 FluidTensor<double, 2> load(const std::string& audio_path,
                             const std::string& file)
 {
-  HISSTools::IAudioFile f(audio_path + "/" + file);
-  auto                  e = f.getErrors();
+  htl::in_audio_file f(audio_path + "/" + file);
+  auto                  e = f.get_errors();
   if (e.size())
   {
-    throw std::runtime_error(HISSTools::BaseAudioFile::getErrorString(e[0]));
+    throw std::runtime_error(f.error_string(e[0]));
   }
 
-  FluidTensor<double, 2> data(f.getChannels(), f.getFrames());
-  f.readInterleaved(data.data(), f.getFrames());
-  e = f.getErrors();
+  FluidTensor<double, 2> data(f.channels(), f.frames());
+  f.read_interleaved(data.data(), f.frames());
+  e = f.get_errors();
   if (e.size())
   {
-    throw std::runtime_error(HISSTools::BaseAudioFile::getErrorString(e[0]));
+    throw std::runtime_error(f.error_string(e[0]));
   }
 
   return data;


### PR DESCRIPTION
This is a PR that updates code and CMake files to deal with HISSTools_Library in header only format, which will be the future of the library.

The changes in the repo have been tested for compilation, but it would be advisable to run some audio tests for sanity in the SC repo and also do some audio testing. In terms of impact on the flucoma ecosystem this pulls in the header-only version of the FFT, which is edited from the previous version - there is no specific reason to expect any issue, but any obvious error is likely to turn up in basic audio testing pretty easily.