### PR TITLE
NMFCross: fix polyphony's default value not being odd as requested

### DIFF
--- a/include/clients/nrt/NMFCrossClient.hpp
+++ b/include/clients/nrt/NMFCrossClient.hpp
@@ -40,7 +40,7 @@ constexpr auto NMFCrossParams = defineParameters(
     InputBufferParam("target", "Target Buffer"),
     BufferParam("output", "Output Buffer"),
     LongParam("timeSparsity", "Time Sparsity", 7, Min(1), Odd()),
-    LongParam("polyphony", "Polyphony", 10, Min(1), Odd(),
+    LongParam("polyphony", "Polyphony", 11, Min(1), Odd(),
               FrameSizeUpperLimit<kFFT>()),
     LongParam("continuity", "Continuity", 7, Min(1), Odd()),
     LongParam("iterations", "Number of Iterations", 50, Min(1)),


### PR DESCRIPTION
Hello both

i don't know why the client asks for Odd() but it does. With a default value of 10 in there, there was a little complaining and it was pushed to 11. Is the Odd() request wrong, or was the default wrong? I actionned a fix assuming the latter, but happy to discuss.