### PR TITLE
Add missing python dependencies to requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ sphinx
 breathe
 myst-parser
 sphinx-book-theme
+schema


### PR DESCRIPTION
When building docs, I made a virtual environment and `pip install -r docs/requirements.txt`.
Got errors building because module 'schema' was not found. Here I've added it to requirements.txt
