### PR TITLE
Tree making overrun in UMAP - fixes #277 and #278

### DIFF
--- a/include/clients/nrt/UMAPClient.hpp
+++ b/include/clients/nrt/UMAPClient.hpp
@@ -79,8 +79,8 @@ public:
     auto src = srcPtr->getDataSet();
     auto dest = destPtr->getDataSet();
     if (src.size() == 0) return Error(EmptyDataSet);
-    if (get<kNumNeighbors>() > src.size())
-      return Error("Number of Neighbours is larger than dataset");
+    if (get<kNumNeighbors>() >= src.size())
+      return Error("Number of Neighbours is greater or equal to the size of the the dataset");
     FluidDataSet<string, double, 1> result;
     try
     {


### PR DESCRIPTION
The tree-making seems to need to remove the front of the matrix - there is a boolean in the algo, but since tree making can be run on a square matrix elsewhere in the codebase, this was creating an overflow in UMAP as the client was not checking for a smaller number of neighbour than the number of points.

@weefuzzy and @g-roma if the rejection of the first item at UMAP.hpp:373 in fluid::algorithm::UMAP::makeGraph is right for the algo (I am not certain) then this fixes everything.