### PR TITLE
fix max fft size fiasco

### DIFF
--- a/include/algorithms/util/FFT.hpp
+++ b/include/algorithms/util/FFT.hpp
@@ -39,8 +39,8 @@ public:
   FFTSetup(FFTSetup const&) = delete;
   FFTSetup& operator=(FFTSetup const&) = delete;
 
-  FFTSetup(FFTSetup&& other) { *this = std::move(other); };
-  FFTSetup& operator=(FFTSetup&& other)
+  FFTSetup(FFTSetup&& other) noexcept { *this = std::move(other); };
+  FFTSetup& operator=(FFTSetup&& other) noexcept
   {
     using std::swap;
     swap(mMaxSize, other.mMaxSize);

--- a/include/algorithms/util/FFT.hpp
+++ b/include/algorithms/util/FFT.hpp
@@ -63,8 +63,6 @@ class FFT
 public:
   using MapXcd = Eigen::Map<Eigen::ArrayXcd>;
 
- //TODO: why is this here? 
- static void setup() { getFFTSetup(); }
 
   FFT() = delete;
 

--- a/include/algorithms/util/FFT.hpp
+++ b/include/algorithms/util/FFT.hpp
@@ -14,6 +14,7 @@ under the European Union’s Horizon 2020 research and innovation programme
 #include "../../data/FluidMemory.hpp"
 #include <Eigen/Core>
 #include <fft/fft.hpp>
+#include <optional> 
 
 namespace fluid {
 namespace algorithm {
@@ -62,13 +63,15 @@ class FFT
 public:
   using MapXcd = Eigen::Map<Eigen::ArrayXcd>;
 
-  static void setup() { getFFTSetup(); }
+ //TODO: why is this here? 
+ static void setup() { getFFTSetup(); }
 
   FFT() = delete;
 
   FFT(index size, Allocator& alloc = FluidDefaultAllocator()) noexcept
       : mMaxSize(size), mSize(size), mFrameSize(size / 2 + 1),
-        mLog2Size(static_cast<index>(std::log2(size))), mSetup(getFFTSetup()),
+        mLog2Size(static_cast<index>(std::log2(size))), 
+        mSetup(getFFTSetup(*this, size)),
         mRealBuffer(asUnsigned(mFrameSize), alloc),
         mImagBuffer(asUnsigned(mFrameSize), alloc),
         mOutputBuffer(asUnsigned(mFrameSize), alloc)
@@ -106,11 +109,18 @@ public:
     return {mOutputBuffer.data(), mFrameSize};
   }
 
+private: 
+  std::optional<impl::FFTSetup> mLocalSetup;   
 protected:
-  static htl::setup_type<double> getFFTSetup()
-  {
-    static const impl::FFTSetup static_setup(65536);
-    return static_setup();
+  static constexpr index default_max = 65536; 
+  static htl::setup_type<double> getFFTSetup(FFT& _this, index size)
+  {    
+    static const impl::FFTSetup static_setup(default_max);
+    if(size <= default_max) return static_setup(); 
+    else {
+      _this.mLocalSetup = std::optional<impl::FFTSetup>(size); 
+      return _this.mLocalSetup->operator()(); 
+    }      
   }
 
   index mMaxSize{16384};
@@ -126,6 +136,7 @@ protected:
 private:
   rt::vector<std::complex<double>> mOutputBuffer;
 };
+
 
 class IFFT : public FFT
 {


### PR DESCRIPTION
What is the road to where paved with? 

This hopefully fixes #258 

`FFT` had been altered some time ago to use a global `setup` object in order to cut down on these expensive things being redundantly created all over the place (quite possibly on the heap? Can't remember...). Instead an assumed hard limit of 2^16 Became A Thing. Unfortunately, nobody (i.e. me) told the rest of the codebase, which happily assumed that anything was possible. Moreover, (a) `FFT::resize()` is assumed by calling code not to fail (!?) and (b) its `assert` was useless because `FFT` was still cheerfully accepting fft sizes > 2^16, even if its `setup` object could never honour that. 

(Seems like now would be a good time to have more unit tests) 

So. I still like the idea of 'normal' FFT usage not spraying lots of these `setup` objects out into the world, but have attempted to accommodate the adventurous by allowing a local `setup` object in a `std::optional` when a chunkier size is requested.    

So far, this is tested only to the extent of seeing if I could run NMF in Max with a FFT of 2**17. I will at least confirm that when fft size is <= 2**16, it continues to use the default path, but more dedicated tyre kicking by @tremblap will be helpful. 



 