### PR TITLE
Crashes with JSON generated by empty objects

### DIFF
--- a/include/clients/nrt/KNNClassifierClient.hpp
+++ b/include/clients/nrt/KNNClassifierClient.hpp
@@ -43,7 +43,10 @@ void to_json(nlohmann::json& j, const KNNClassifierData& data)
 bool check_json(const nlohmann::json& j, const KNNClassifierData&)
 {
   return fluid::check_json(j, {"tree", "labels"},
-                           {JSONTypes::OBJECT, JSONTypes::OBJECT});
+                           {JSONTypes::OBJECT, JSONTypes::OBJECT}) &&
+         fluid::algorithm::check_json(j.at("tree"), algorithm::KDTree()) &&
+         fluid::check_json(j.at("labels"),
+                           FluidDataSet<std::string, std::string, 1>());
 }
 
 void from_json(const nlohmann::json& j, KNNClassifierData& data)

--- a/include/clients/nrt/KNNClassifierClient.hpp
+++ b/include/clients/nrt/KNNClassifierClient.hpp
@@ -22,7 +22,7 @@ namespace knnclassifier {
 
 struct KNNClassifierData
 {
-  algorithm::KDTree                         tree{0};
+  algorithm::KDTree                         tree{algorithm::KDTree()};
   FluidDataSet<std::string, std::string, 1> labels{1};
   index size() const { return labels.size(); }
   index dims() const { return tree.dims(); }

--- a/include/clients/nrt/KNNClassifierClient.hpp
+++ b/include/clients/nrt/KNNClassifierClient.hpp
@@ -24,9 +24,9 @@ struct KNNClassifierData
 {
   algorithm::KDTree                         tree{0};
   FluidDataSet<std::string, std::string, 1> labels{1};
-  index                                     size() const { return labels.size(); }
-  index                                     dims() const { return tree.dims(); }
-  void                                      clear()
+  index size() const { return labels.size(); }
+  index dims() const { return tree.dims(); }
+  void  clear()
   {
     labels = FluidDataSet<std::string, std::string, 1>(1);
     tree.clear();
@@ -135,14 +135,14 @@ public:
     algorithm::KNNClassifier classifier;
     RealVector               point(mAlgorithm.tree.dims());
     point <<= BufferAdaptor::ReadAccess(data.get())
-                .samps(0, mAlgorithm.tree.dims(), 0);
+                  .samps(0, mAlgorithm.tree.dims(), 0);
     std::string result = classifier.predict(mAlgorithm.tree, point,
                                             mAlgorithm.labels, k, weight);
     return result;
   }
 
-  MessageResult<void> predict(InputDataSetClientRef  source,
-                              LabelSetClientRef dest) const
+  MessageResult<void> predict(InputDataSetClientRef source,
+                              LabelSetClientRef     dest) const
   {
     index k = get<kNumNeighbors>();
     bool  weight = get<kWeight>() != 0;
@@ -166,7 +166,7 @@ public:
     {
       RealVectorView point = data.row(i);
       StringVector   label = {classifier.predict(mAlgorithm.tree, point,
-                                               mAlgorithm.labels, k, weight)};
+                                                 mAlgorithm.labels, k, weight)};
       result.add(ids(i), label);
     }
     destPtr->setLabelSet(result);
@@ -189,7 +189,7 @@ public:
         makeMessage("read", &KNNClassifierClient::read));
   }
 
-  index encodeIndex(std::string const& label) const 
+  index encodeIndex(std::string const& label) const
   {
     return mLabelSetEncoder.encodeIndex(label);
   }

--- a/include/clients/nrt/KNNRegressorClient.hpp
+++ b/include/clients/nrt/KNNRegressorClient.hpp
@@ -131,24 +131,25 @@ public:
     if (mAlgorithm.tree.size() < k) return Error(NotEnoughData);
 
     InBufferCheck bufCheck(mAlgorithm.tree.dims());
-    if (!bufCheck.checkInputs(in.get()))
-      return Error(bufCheck.error());
+    if (!bufCheck.checkInputs(in.get())) return Error(bufCheck.error());
     BufferAdaptor::ReadAccess inBuf(in.get());
-    BufferAdaptor::Access outBuf(out.get());
+    BufferAdaptor::Access     outBuf(out.get());
     if (!outBuf.exists()) return Error(InvalidBuffer);
-    Result resizeResult = outBuf.resize(mAlgorithm.target.dims(), 1, inBuf.sampleRate());
+    Result resizeResult =
+        outBuf.resize(mAlgorithm.target.dims(), 1, inBuf.sampleRate());
     if (!resizeResult.ok()) return Error(BufferAlloc);
     algorithm::KNNRegressor regressor;
     RealVector              input(mAlgorithm.tree.dims());
     RealVector              output(mAlgorithm.target.dims());
     input <<= inBuf.samps(0, mAlgorithm.tree.dims(), 0);
-    regressor.predict(mAlgorithm.tree, mAlgorithm.target, input, output, k, weight);
+    regressor.predict(mAlgorithm.tree, mAlgorithm.target, input, output, k,
+                      weight);
     outBuf.samps(0) <<= output;
     return OK();
   }
 
   MessageResult<void> predict(InputDataSetClientRef source,
-                              DataSetClientRef dest) const
+                              DataSetClientRef      dest) const
   {
     index k = get<kNumNeighbors>();
     bool  weight = get<kWeight>() != 0;
@@ -172,7 +173,8 @@ public:
     for (index i = 0; i < dataSet.size(); i++)
     {
       RealVectorView point = data.row(i);
-      regressor.predict(mAlgorithm.tree, mAlgorithm.target, point, prediction, k, weight);
+      regressor.predict(mAlgorithm.tree, mAlgorithm.target, point, prediction,
+                        k, weight);
       result.add(ids(i), prediction);
     }
     destPtr->setDataSet(result);
@@ -265,9 +267,10 @@ public:
       RealVector output(algorithm.target.dims(), c.allocator());
 
       input <<= BufferAdaptor::ReadAccess(get<kInputBuffer>().get())
-                  .samps(0, algorithm.tree.dims(), 0);
+                    .samps(0, algorithm.tree.dims(), 0);
 
-      regressor.predict(algorithm.tree, algorithm.target, input, output, k, weight, c.allocator());
+      regressor.predict(algorithm.tree, algorithm.target, input, output, k,
+                        weight, c.allocator());
       outBuf.samps(0) <<= output;
     }
   }

--- a/include/clients/nrt/KNNRegressorClient.hpp
+++ b/include/clients/nrt/KNNRegressorClient.hpp
@@ -41,7 +41,10 @@ void to_json(nlohmann::json& j, const KNNRegressorData& data)
 bool check_json(const nlohmann::json& j, const KNNRegressorData&)
 {
   return fluid::check_json(j, {"tree", "target"},
-                           {JSONTypes::OBJECT, JSONTypes::OBJECT});
+                           {JSONTypes::OBJECT, JSONTypes::OBJECT}) &&
+         fluid::algorithm::check_json(j.at("tree"), algorithm::KDTree()) &&
+         fluid::check_json(j.at("labels"),
+                           FluidDataSet<std::string, std::string, 1>());
 }
 
 void from_json(const nlohmann::json& j, KNNRegressorData& data)

--- a/include/clients/nrt/KNNRegressorClient.hpp
+++ b/include/clients/nrt/KNNRegressorClient.hpp
@@ -20,7 +20,7 @@ namespace knnregressor {
 
 struct KNNRegressorData
 {
-  algorithm::KDTree                    tree{0};
+  algorithm::KDTree                    tree{algorithm::KDTree()};
   FluidDataSet<std::string, double, 1> target{1};
   index                                size() const { return target.size(); }
   index                                dims() const { return tree.dims(); }


### PR DESCRIPTION
Motivating incident was discovering that with an 'empty' `KNNClassifier` we can generate JSON that will then cause a crash on read (#274)

First commit here 'fixes' that by identifying such JSON as invalid and error-ing out instead (`KNNClassifier` JSON is combination of `KDTree` and `Dataset` but only the top level was being checked. Now we check the sub-objects by delegating to their JSON validation fns) 


Now we need to check the other serializable objects too. 

- [x] DataSet
- [x] DataSetQuery
- [x] LabelSet
- [x] KDTree
- [x] KMeans
- [x] SKMeans
- [x] KNNClassifier
- [x] KNNRegressor
- [x] Normalize
- [x] RobustScale
- [x] Standardize
- [x] PCA
- [x] MDS
- [x] UMAP
- [x] MLPRegressor
- [x] MLPClassifier
- [x] Grid

