### PR TITLE
Enhance/skmeans convergence

### DIFF
--- a/include/algorithms/public/SKMeans.hpp
+++ b/include/algorithms/public/SKMeans.hpp
@@ -88,9 +88,8 @@ private:
   {
     for (index i = 0; i < mAssignments.cols(); i++)
     {
-      double val = mEmbedding(mAssignments(i), i);
       mEmbedding.col(i).setZero();
-      mEmbedding(mAssignments(i), i) = val;
+      mEmbedding(mAssignments(i), i) = 1.0;
     }
   }
 

--- a/include/algorithms/public/SKMeans.hpp
+++ b/include/algorithms/public/SKMeans.hpp
@@ -33,7 +33,8 @@ public:
     using namespace Eigen;
     using namespace _impl;
     assert(!mTrained || (dataset.pointSize() == mDims && mK == k));
-    MatrixXd dataPoints = asEigen<Matrix>(dataset.getData());
+    MatrixXd dataPoints =
+        asEigen<Matrix>(dataset.getData()).colwise().normalized();
     MatrixXd dataPointsT = dataPoints.transpose();
     if (mTrained) { mAssignments = assignClusters(dataPointsT);}
     else


### PR DESCRIPTION
Responding to queries from @tremblap about how well skmeans was behaving, this makes two changes 

1. Normalize the input data to the unit sphere. Otherwise taking the dot product of the centroids and data doesn't yield cosine similarities. 
2. When the embedding matrix is made sparse after assignment, the assigned cells should be `1` if the subsequent multiplication with the data is to yield usefully convergent means (well, sums in this case). 

This PR to be followed closely with an update to the initialisation. 
---

### Note to future me: 
There's maybe a more Eigenonic way to do (2) that can get us a sparse matrix to make updating the means more efficient. But for now I've just kept the changes as small as possible.  

```c++
    // an expression that will return a matrix with each col filled with m's column-wise maxima 
    auto maxes = m.colwise().maxCoeff().replicate(m.rows(),1);
   // convert to 0s and 1s by testing for equality with the maxima 
    SparseMatrix<double> s =  (m.array() == maxes.array()).matrix().cast<double>().sparseView(); 
```

(With this, we could probably also get rid of a separate `assignClusters` step, as that would be encoded in the sparse matrix. However, now that I re-read it, I see that there's a possible ambiguous situation when a column has two exactly equal values that are maxima...)