### PR TITLE
Enhancing K-Means initialization options

### DIFF
--- a/include/clients/nrt/SKMeansClient.hpp
+++ b/include/clients/nrt/SKMeansClient.hpp
@@ -20,13 +20,15 @@ namespace fluid {
 namespace client {
 namespace skmeans {
 
-enum { kName, kNumClusters, kThreshold, kMaxIter };
+enum { kName, kNumClusters, kThreshold, kMaxIter, kInit };
 
 constexpr auto SKMeansParams = defineParameters(
     StringParam<Fixed<true>>("name", "Name"),
     LongParam("numClusters", "Number of Clusters", 4, Min(0)),
     FloatParam("encodingThreshold", "Encoding Threshold", 0.25, Min(0), Max(1)),
-    LongParam("maxIter", "Max number of Iterations", 100, Min(1)));
+    LongParam("maxIter", "Max number of Iterations", 100, Min(1)), 
+    EnumParam("initialize","Initialize method",0, "Random Assignment", "Sampled Means") 
+  );
 
 class SKMeansClient : public FluidBaseClient,
                       OfflineIn,
@@ -79,7 +81,7 @@ public:
     if (dataSet.size() == 0) return Error<IndexVector>(EmptyDataSet);
     if (k <= 1) return Error<IndexVector>(SmallK);
     if(mTracker.changed(k)) mAlgorithm.clear(); 
-    mAlgorithm.train(dataSet, k, maxIter);
+    mAlgorithm.train(dataSet, k, maxIter, get<kInit>());
     IndexVector assignments(dataSet.size());
     mAlgorithm.getAssignments(assignments);
     return getCounts(assignments, k);
@@ -100,7 +102,7 @@ public:
     if (k <= 1) return Error<IndexVector>(SmallK);
     if (maxIter <= 0) maxIter = 100;
     if(mTracker.changed(k)) mAlgorithm.clear(); 
-    mAlgorithm.train(dataSet, k, maxIter);
+    mAlgorithm.train(dataSet, k, maxIter, get<kInit>());
     IndexVector assignments(dataSet.size());
     mAlgorithm.getAssignments(assignments);
     StringVectorView ids = dataSet.getIds();
@@ -171,7 +173,7 @@ public:
     if (k <= 1) return Error<IndexVector>(SmallK);
     if (maxIter <= 0) maxIter = 100;
     if(mTracker.changed(k)) mAlgorithm.clear(); 
-    mAlgorithm.train(dataSet, k, maxIter);
+    mAlgorithm.train(dataSet, k, maxIter,get<kInit>());
     IndexVector assignments(dataSet.size());
     mAlgorithm.getAssignments(assignments);
     encode(srcClient, dstClient);


### PR DESCRIPTION
We're finding that `SKMeans` can perform quite poorly with the random partition method of initialization, insofar as it is prone to get stuck in local minima. 

This can be a problem for k-means more generally (see [1]), depending on the distribution of the data: k-means's hard assignment means that a poor choice of initial centroids is more likely with random partition and unlikely to converge well in the subsequent iterations. 

This PR explores improvements. First by adding an option to sk-means for 'Forgy' initialisation, which just initializes the means by sampling `k` points from the data. This seems to produce improvements for sk-means in some simple cases. However, it's still not the state of the art in initialization procedures, because it depends on how representative those `k` samples are. 

More sophisticated schemes such as k-means++ build up a more accurate approximation of the data distribution and sample from that. k-means++ is expensive however. Fortunately there are now more efficient approximate schemes for this that use MCMC to approximate the distribution with only a single pass over the data. 

This PR will stay WIP for a bit whilst we explore this in a controlled way. This initial commit aims at a minimal set of changes to skmeans to provide the choice of initialisations. I imagine the following steps: 

- [ ] verify that `Forgy` initialization  can improve matters for sk-means 
- [ ] refactor k-means a bit so that it can offer a choice of init schemes too 
- [ ] develop and test MCMC initialisation for both k-means and sk-means 

----

[1] Greg Hamerly and Charles Elkan. 2002. Alternatives to the k-means algorithm that find better clusterings. In Proceedings of the eleventh international conference on Information and knowledge management (CIKM '02). Association for Computing Machinery, New York, NY, USA, 600–607. https://doi.org/10.1145/584792.584890

