### PR TITLE
Fix FluidTransient<Slice> allocations 

### DIFF
--- a/include/algorithms/public/TransientExtraction.hpp
+++ b/include/algorithms/public/TransientExtraction.hpp
@@ -42,7 +42,10 @@ public:
         mBackwardError(asUnsigned(maxBlockSize + maxOrder), alloc),
         mForwardWindowedError(asUnsigned(maxBlockSize), alloc),
         mBackwardWindowedError(asUnsigned(maxBlockSize), alloc)
-  {}
+  {
+    assert(maxBlockSize >= maxOrder && "Max block size needs to be >= max order"); 
+    assert(maxPadSize >= maxOrder && "Max pad size needs to be >= max order"); 
+  }
 
   void init(index order, index blockSize, index padSize)
   {

--- a/include/clients/rt/TransientClient.hpp
+++ b/include/clients/rt/TransientClient.hpp
@@ -39,7 +39,7 @@ enum TransientParamIndex {
 
 constexpr index transientMaxOrder = 200; 
 constexpr index transientMaxBlockSize = 4096; 
-constexpr index transientMaxPadding = 256;
+constexpr index transientMaxPadding = 1024;
 
 constexpr auto TransientParams = defineParameters(
     LongParam("order", "Order", 20, Min(10), LowerLimit<kWinSize>(),

--- a/include/clients/rt/TransientSliceClient.hpp
+++ b/include/clients/rt/TransientSliceClient.hpp
@@ -36,11 +36,16 @@ enum TransientParamIndex {
   kMinSeg
 };
 
+constexpr index transientMaxOrder = 200; 
+constexpr index transientMaxBlockSize = 4096; 
+constexpr index transientMaxPadding = 256;
+
 constexpr auto TransientSliceParams = defineParameters(
     LongParam("order", "Order", 20, Min(10), LowerLimit<kWinSize>(),
-              UpperLimit<kBlockSize>(), Max(200)),
-    LongParam("blockSize", "Block Size", 256, Min(100), LowerLimit<kOrder>(), Max(4096)),
-    LongParam("padSize", "Padding", 128, Min(0)),
+              UpperLimit<kBlockSize>(), Max(transientMaxOrder)),
+    LongParam("blockSize", "Block Size", 256, Min(100), LowerLimit<kOrder>(),
+              Max(transientMaxBlockSize)),
+    LongParam("padSize", "Padding", 128, Min(0), Max(transientMaxPadding)),
     FloatParam("skew", "Skew", 0, Min(-10), Max(10)),
     FloatParam("threshFwd", "Forward Threshold", 2, Min(0)),
     FloatParam("threshBack", "Backward Threshold", 1.1, Min(0)),
@@ -72,10 +77,13 @@ public:
   }
 
   TransientSliceClient(ParamSetViewType& p, FluidContext& c)
-    : mParams{p},mMaxWindowIn{2 * get<kBlockSize>() + get<kPadding>()},
-      mMaxWindowOut{get<kBlockSize>()},
-      mExtractor{get<kOrder>(), get<kBlockSize>(), get<kPadding>(), c.allocator()},
-      mBufferedProcess{mMaxWindowIn, mMaxWindowOut, 1, 1, c.hostVectorSize(), c.allocator()}
+      : mParams{p},
+        mMaxWindowIn{2 * transientMaxBlockSize + transientMaxPadding},
+        mMaxWindowOut{transientMaxBlockSize},
+        mExtractor{transientMaxOrder, transientMaxBlockSize,
+                   transientMaxPadding, c.allocator()},
+        mBufferedProcess{mMaxWindowIn,       mMaxWindowOut, 1, 1,
+                         c.hostVectorSize(), c.allocator()}
   {
     audioChannelsIn(1);
     audioChannelsOut(1);

--- a/include/clients/rt/TransientSliceClient.hpp
+++ b/include/clients/rt/TransientSliceClient.hpp
@@ -38,7 +38,7 @@ enum TransientParamIndex {
 
 constexpr index transientMaxOrder = 200; 
 constexpr index transientMaxBlockSize = 4096; 
-constexpr index transientMaxPadding = 256;
+constexpr index transientMaxPadding = 1024;
 
 constexpr auto TransientSliceParams = defineParameters(
     LongParam("order", "Order", 20, Min(10), LowerLimit<kWinSize>(),


### PR DESCRIPTION
Fixes #270 

* Ensure that clients instantiate the transient algorithms with actually sensible max values for order, blocksize, padding
* Add some extra asserts to make future us have an easier time tracing this stuff 
* Properly finish the job for ARModel and ensure that the model order no longer assumed to be the size of the parameters vector 😬 