### PR TITLE
Ensures source and target IDs are paired up in SGD

### DIFF
--- a/include/flucoma/algorithms/public/MLP.hpp
+++ b/include/flucoma/algorithms/public/MLP.hpp
@@ -30,8 +30,6 @@ class MLP
   using ArrayXXd = Eigen::ArrayXXd;
 
 public:
-  explicit MLP() = default;
-  ~MLP() = default;
 
   void init(index inputSize, index outputSize,
             FluidTensor<index, 1> hiddenSizes, index hiddenAct, index outputAct)

--- a/include/flucoma/algorithms/public/SGD.hpp
+++ b/include/flucoma/algorithms/public/SGD.hpp
@@ -15,10 +15,10 @@ under the European Union’s Horizon 2020 research and innovation programme
 #include "../../data/FluidDataSet.hpp"
 #include "../../data/FluidIndex.hpp"
 #include "../../data/FluidTensor.hpp"
+#include "../../data/SimpleDataSampler.hpp"
 #include "../../data/TensorTypes.hpp"
 #include <Eigen/Core>
 #include <limits>
-#include <random>
 
 namespace fluid {
 namespace algorithm {
@@ -27,72 +27,63 @@ class SGD
 {
   using ArrayXd = Eigen::ArrayXd;
   using ArrayXXd = Eigen::ArrayXXd;
-  using Permutation = Eigen::PermutationMatrix<Eigen::Dynamic, Eigen::Dynamic>;
 
 public:
-  explicit SGD() = default;
-  ~SGD() = default;
 
-  double train(MLP& model, const RealMatrixView in, RealMatrixView out,
+  double train(MLP& model, InputRealMatrixView in, RealMatrixView out,
                index nIter, index batchSize, double learningRate,
                double momentum, double valFrac)
+  {
+    return train(model, in, out,
+                 SimpleDataSampler(in.rows(), batchSize, valFrac, true), nIter,
+                 learningRate, momentum);
+  }
+
+  template <typename Sampler>
+  double train(MLP& model, InputRealMatrixView in, RealMatrixView out,
+               Sampler&& loader, index nIter, double learningRate,
+               double momentum)
   {
     using namespace _impl;
     using namespace std;
     using namespace Eigen;
-    index       nExamples = in.rows();
-    index       inputSize = in.cols();
-    index       outputSize = out.cols();
-    ArrayXXd    input = asEigen<Eigen::Array>(in);
-    ArrayXXd    output = asEigen<Eigen::Array>(out);
-    Permutation valPerm(nExamples);
-    valPerm.setIdentity();
-    shuffle(valPerm.indices().data(),
-            valPerm.indices().data() + valPerm.indices().size(),
-            mt19937{random_device{}()});
-    input = valPerm * input.matrix();
-    output = valPerm * output.matrix();
-    index nVal = std::lround(nExamples * valFrac);
-    index nTrain = nExamples - nVal;
+    index nExamples = in.rows();
+    // index inputSize = in.cols();
+    index outputSize = out.cols();
 
-    ArrayXXd trainInput = input.block(0, 0, nTrain, inputSize);
-    ArrayXXd trainOutput = output.block(0, 0, nTrain, outputSize);
-    ArrayXXd valInput = input.block(nTrain, 0, nVal, inputSize);
-    ArrayXXd valOutput = output.block(nTrain, 0, nVal, outputSize);
+    auto                    valIdx = loader.validationSet();
+    std::optional<ArrayXXd> valInput;
+    std::optional<ArrayXXd> valOutput;
+    if (valIdx)
+    {
+      valInput =
+          ArrayXXd(asEigen<Eigen::Array>(in)(valIdx->col(0), Eigen::all));
+      valOutput =
+          ArrayXXd(asEigen<Eigen::Array>(in)(valIdx->col(1), Eigen::all));
+    }
 
-    Permutation iterPerm(nTrain);
-    iterPerm.setIdentity();
     double error = 0;
     index  patience = mInitialPatience;
     double prevValLoss = std::numeric_limits<double>::max();
     while (nIter-- > 0)
     {
-      shuffle(iterPerm.indices().data(),
-              iterPerm.indices().data() + iterPerm.indices().size(),
-              mt19937{random_device{}()});
-      ArrayXXd inPerm = iterPerm * trainInput.matrix();
-      ArrayXXd outPerm = iterPerm * trainOutput.matrix();
-      for (index batchStart = 0; batchStart < inPerm.rows();
-           batchStart += batchSize)
+      for (auto batch : loader)
       {
-        index thisBatchSize = (batchStart + batchSize) <= nTrain
-                                  ? batchSize
-                                  : nTrain - batchStart;
-        ArrayXXd batchIn =
-            inPerm.block(batchStart, 0, thisBatchSize, inPerm.cols());
+        index    thisBatchSize = batch->rows();
+        ArrayXXd batchIn = asEigen<Eigen::Array>(in)(batch->col(0), Eigen::all);
         ArrayXXd batchOut =
-            outPerm.block(batchStart, 0, thisBatchSize, outPerm.cols());
+            asEigen<Eigen::Array>(out)(batch->col(1), Eigen::all);
         ArrayXXd batchPred = ArrayXXd::Zero(thisBatchSize, outputSize);
         model.forward(batchIn, batchPred);
         ArrayXXd diff = batchPred - batchOut;
         model.backward(diff);
         model.update(learningRate, momentum);
       }
-      if (nVal > 0)
+      if (valIdx)
       {
-        ArrayXXd valPred = ArrayXXd::Zero(nVal, outputSize);
-        model.forward(valInput, valPred);
-        double valLoss = model.loss(valPred, valOutput);
+        ArrayXXd valPred = ArrayXXd::Zero(valInput->rows(), outputSize);
+        model.forward(*valInput, valPred);
+        double valLoss = model.loss(valPred, *valOutput);
         if (valLoss < prevValLoss)
           patience = mInitialPatience;
         else
@@ -101,6 +92,13 @@ public:
         prevValLoss = valLoss;
       }
     }
+
+    auto trainingIdx = loader.trainingSet();
+    nExamples = trainingIdx->rows();
+    ArrayXXd input = asEigen<Eigen::Array>(in)(trainingIdx->col(0), Eigen::all);
+    ArrayXXd output =
+        asEigen<Eigen::Array>(out)(trainingIdx->col(1), Eigen::all);
+
     ArrayXXd finalPred = ArrayXXd::Zero(nExamples, outputSize);
     model.forward(input, finalPred);
     bool isNan = !((finalPred == finalPred)).all();

--- a/include/flucoma/algorithms/public/SGD.hpp
+++ b/include/flucoma/algorithms/public/SGD.hpp
@@ -59,7 +59,7 @@ public:
       valInput =
           ArrayXXd(asEigen<Eigen::Array>(in)(valIdx->col(0), Eigen::all));
       valOutput =
-          ArrayXXd(asEigen<Eigen::Array>(in)(valIdx->col(1), Eigen::all));
+          ArrayXXd(asEigen<Eigen::Array>(out)(valIdx->col(1), Eigen::all));
     }
 
     double error = 0;

--- a/include/flucoma/clients/nrt/CommonResults.hpp
+++ b/include/flucoma/clients/nrt/CommonResults.hpp
@@ -40,6 +40,7 @@ static const std::string FileRead{"Couldn't read file"};
 static const std::string FileWrite{"Couldn't write file"};
 static const std::string NotImplemented{"Not implemented"};
 static const std::string SizesDontMatch{"Sizes do not match"};
+static const std::string TooFewOutputPoints{"Not enough output points"};
 static const std::string DimensionsDontMatch{"Dimensions do not match"};
 
 template <typename T>

--- a/include/flucoma/data/FluidDataSet.hpp
+++ b/include/flucoma/data/FluidDataSet.hpp
@@ -13,7 +13,7 @@ namespace fluid {
 template <typename idType, typename dataType, index N>
 class FluidDataSet
 {
-  template<typename ID, typename U, index M> 
+  template<typename, typename, index> 
   friend class FluidDataSet; 
 
 public:
@@ -199,7 +199,7 @@ public:
   }
 
   template<typename T, index M> 
-  friend auto indexMap(FluidDataSet<idType, T, M> const& x, FluidDataSet const& y)
+  auto indexMap(FluidDataSet<idType, T, M> const& x) const
     -> std::pair<std::vector<index>,std::vector<index>>
   {
     using std::pair, std::vector, std::begin, std::end; 
@@ -212,9 +212,9 @@ public:
     auto lastID = end(x.getIds());
 
     std::transform(firstID, lastID, std::back_inserter(result.first),
-                   [&x](auto const& id) { return x.mIndex.at(id); });
+                   [this](auto const& id) { return mIndex.at(id); });
     std::transform(firstID, lastID, std::back_inserter(result.second),
-                   [&y](auto const& id) { return y.mIndex.at(id); });
+                   [&x](auto const& id) { return x.mIndex.at(id); });
 
     return result;
   }

--- a/include/flucoma/data/FluidDataSet.hpp
+++ b/include/flucoma/data/FluidDataSet.hpp
@@ -13,6 +13,8 @@ namespace fluid {
 template <typename idType, typename dataType, index N>
 class FluidDataSet
 {
+  template<typename ID, typename U, index M> 
+  friend class FluidDataSet; 
 
 public:
   explicit FluidDataSet() = default;
@@ -64,7 +66,7 @@ public:
     }
   }
 
-  bool add(idType const& id, FluidTensorView<dataType, N> point)
+  bool add(idType const& id, FluidTensorView<const dataType, N> point)
   {
     assert(sameExtents(mDim, point.descriptor()));
     index pos = mData.rows();
@@ -194,6 +196,40 @@ public:
       }
     }
     return result.str();
+  }
+
+  template<typename T, index M> 
+  friend auto indexMap(FluidDataSet<idType, T, M> const& x, FluidDataSet const& y)
+    -> std::pair<std::vector<index>,std::vector<index>>
+  {
+    using std::pair, std::vector, std::begin, std::end; 
+
+    pair<vector<index>, vector<index>> result; 
+    result.first.reserve(x.size());
+    result.second.reserve(x.size());
+
+    auto firstID = begin(x.getIds());
+    auto lastID = end(x.getIds());
+
+    std::transform(firstID, lastID, std::back_inserter(result.first),
+                   [&x](auto const& id) { return x.mIndex.at(id); });
+    std::transform(firstID, lastID, std::back_inserter(result.second),
+                   [&y](auto const& id) { return y.mIndex.at(id); });
+
+    return result;
+  }
+
+  template <class U, index M>
+  std::vector<idType> checkIDs(FluidDataSet<idType, U, M> const& other) const
+  {
+    std::vector<idType> result;
+
+    std::for_each(mIndex.begin(), mIndex.end(), [&result, &other](auto& item) {
+      if (other.mIndex.find(item.first) == other.mIndex.end())
+        result.push_back(item.first);
+    });
+
+    return result;
   }
 
 private:

--- a/include/flucoma/data/FluidDataSet.hpp
+++ b/include/flucoma/data/FluidDataSet.hpp
@@ -205,8 +205,8 @@ public:
     using std::pair, std::vector, std::begin, std::end; 
 
     pair<vector<index>, vector<index>> result; 
-    result.first.reserve(x.size());
-    result.second.reserve(x.size());
+    result.first.reserve(asUnsigned(x.size()));
+    result.second.reserve(asUnsigned(x.size()));
 
     auto firstID = begin(x.getIds());
     auto lastID = end(x.getIds());

--- a/include/flucoma/data/FluidDataSetSampler.hpp
+++ b/include/flucoma/data/FluidDataSetSampler.hpp
@@ -1,0 +1,56 @@
+/*
+Part of the Fluid Corpus Manipulation Project (http://www.flucoma.org/)
+Copyright University of Huddersfield.
+Licensed under the BSD-3 License.
+See license.md file in the project root for full license information.
+This project has received funding from the European Research Council (ERC)
+under the European Union’s Horizon 2020 research and innovation programme
+(grant agreement No 725899).
+*/
+
+/*
+Pairing two unordered DataSets for supervised use
+*/
+#pragma once
+
+#include "FluidDataSet.hpp"
+#include "FluidIndex.hpp"
+#include "detail/DataSampler.hpp"
+#include <optional>
+#include <random>
+
+
+namespace fluid {
+
+class FluidDataSetSampler
+    : public detail::DataSampler<FluidDataSetSampler>
+{
+  friend detail::DataSampler<FluidDataSetSampler>;
+
+  std::pair<std::vector<index>, std::vector<index>> mIdxMaps;
+
+  template <class InputIter>
+  FluidTensorView<index, 2> map(InputIter start, InputIter end,
+                                FluidTensorView<index, 2> dst)
+  {
+    using std::begin;
+    auto inputSamples = dst.col(0);
+    auto outputSamples = dst.col(1);
+
+    transform(start, end, begin(inputSamples),
+              [&idx = mIdxMaps](index i) { return idx.first[i]; });
+    transform(start, end, begin(outputSamples),
+              [&idx = mIdxMaps](index i) { return idx.second[i]; });
+    return dst;
+  }
+
+public:
+  template <typename DataSetA, typename DataSetB>
+  FluidDataSetSampler(DataSetA const& in, DataSetB const& out, index batchSize,
+                      double validationFraction, bool shuffle = true)
+      : detail::DataSampler<FluidDataSetSampler>(in.size(), batchSize,
+                                                 validationFraction, shuffle),
+        mIdxMaps{indexMap(in, out)}
+  {}
+};
+} // namespace fluid

--- a/include/flucoma/data/FluidDataSetSampler.hpp
+++ b/include/flucoma/data/FluidDataSetSampler.hpp
@@ -22,8 +22,7 @@ Pairing two unordered DataSets for supervised use
 
 namespace fluid {
 
-class FluidDataSetSampler
-    : public detail::DataSampler<FluidDataSetSampler>
+class FluidDataSetSampler : public detail::DataSampler<FluidDataSetSampler>
 {
   friend detail::DataSampler<FluidDataSetSampler>;
 
@@ -38,9 +37,9 @@ class FluidDataSetSampler
     auto outputSamples = dst.col(1);
 
     transform(start, end, begin(inputSamples),
-              [&idx = mIdxMaps](index i) { return idx.first[i]; });
+              [&idx = mIdxMaps](index i) { return idx.first[asUnsigned(i)]; });
     transform(start, end, begin(outputSamples),
-              [&idx = mIdxMaps](index i) { return idx.second[i]; });
+              [&idx = mIdxMaps](index i) { return idx.second[asUnsigned(i)]; });
     return dst;
   }
 

--- a/include/flucoma/data/FluidDataSetSampler.hpp
+++ b/include/flucoma/data/FluidDataSetSampler.hpp
@@ -50,7 +50,7 @@ public:
                       double validationFraction, bool shuffle = true)
       : detail::DataSampler<FluidDataSetSampler>(in.size(), batchSize,
                                                  validationFraction, shuffle),
-        mIdxMaps{indexMap(in, out)}
+        mIdxMaps{in.indexMap(out)}
   {}
 };
 } // namespace fluid

--- a/include/flucoma/data/FluidTensor.hpp
+++ b/include/flucoma/data/FluidTensor.hpp
@@ -331,7 +331,8 @@ public:
 
   index extent(index n) const { return mDesc.extents[asUnsigned(n)]; };
   index rows() const { return extent(0); }
-  index cols() const { return extent(1); }
+  template <typename dummy = index>
+  std::enable_if_t<N >= 2, dummy> cols() const { return extent(1); }
   index size() const { return asSigned(mContainer.size()); }
   const FluidTensorSlice<N>& descriptor() const { return mDesc; }
   FluidTensorSlice<N>&       descriptor() { return mDesc; }
@@ -710,7 +711,15 @@ public:
 
   const FluidTensorSlice<N> descriptor() const { return mDesc; }
   FluidTensorSlice<N>       descriptor() { return mDesc; }
-
+ 
+  bool operator==(const FluidTensorView& rhs) const {
+    return  data() == rhs.data(); 
+  }
+  
+  bool operator!=(const FluidTensorView& rhs) const {
+    return !(*this == rhs); 
+ }
+ 
   friend void swap(FluidTensorView& first, FluidTensorView& second)
   {
     using std::swap;

--- a/include/flucoma/data/SimpleDataSampler.hpp
+++ b/include/flucoma/data/SimpleDataSampler.hpp
@@ -1,0 +1,46 @@
+/*
+Part of the Fluid Corpus Manipulation Project (http://www.flucoma.org/)
+Copyright University of Huddersfield.
+Licensed under the BSD-3 License.
+See license.md file in the project root for full license information.
+This project has received funding from the European Research Council (ERC)
+under the European Union’s Horizon 2020 research and innovation programme
+(grant agreement No 725899).
+*/
+
+#pragma once
+
+#include "FluidIndex.hpp"
+#include "detail/DataSampler.hpp"
+#include <algorithm>
+#include <random>
+#include <vector>
+
+
+namespace fluid {
+
+class SimpleDataSampler : public detail::DataSampler<SimpleDataSampler>
+{
+  friend detail::DataSampler<SimpleDataSampler>;
+
+  template <class InputIter>
+  FluidTensorView<index, 2> map(InputIter start, InputIter end,
+                                FluidTensorView<index, 2> dst)
+  {
+    using std::begin, std::copy;
+    auto inputSamples = dst.col(0);
+    auto outputSamples = dst.col(1);
+    copy(start, end, begin(inputSamples));
+    copy(start, end, begin(outputSamples));
+    return dst;
+  }
+
+public:
+  SimpleDataSampler(index size, index batchSize, double validationFraction,
+                    bool shuffle)
+      : detail::DataSampler<SimpleDataSampler>(size, batchSize,
+                                               validationFraction, shuffle)
+  {}
+};
+
+} // namespace fluid

--- a/include/flucoma/data/detail/DataSampler.hpp
+++ b/include/flucoma/data/detail/DataSampler.hpp
@@ -70,7 +70,7 @@ class DataSampler
   std::vector<index> makeIndex(index size, bool shuffle)
   {
     using std::begin, std::end;
-    std::vector<index> result(size);
+    std::vector<index> result(asUnsigned(size));
     std::iota(begin(result), end(result), 0);
     if (shuffle) std::shuffle(begin(result), end(result), mGen);
     return result;
@@ -122,6 +122,8 @@ public:
     return derived().map(batchStart, batchEnd, mBatch)(Slice(0, thisBatchSize),
                                                        Slice(0));
   }
+
+  index maxBatchSize() { return mBatchSize + (mTrainCount % mBatchSize); }
 
   std::optional<FluidTensorView<index, 2>> validationSet()
   {

--- a/include/flucoma/data/detail/DataSampler.hpp
+++ b/include/flucoma/data/detail/DataSampler.hpp
@@ -1,0 +1,177 @@
+/*
+Part of the Fluid Corpus Manipulation Project (http://www.flucoma.org/)
+Copyright University of Huddersfield.
+Licensed under the BSD-3 License.
+See license.md file in the project root for full license information.
+This project has received funding from the European Research Council (ERC)
+under the European Union’s Horizon 2020 research and innovation programme
+(grant agreement No 725899).
+*/
+#pragma once
+#include "../FluidTensor.hpp"
+#include <algorithm>
+#include <iterator>
+#include <optional>
+#include <random>
+#include <vector>
+
+namespace fluid::detail {
+template <class Derived>
+class DataSampler
+{
+  struct BatchIterator
+  {
+    using iterator_category = std::input_iterator_tag;
+    using value_type = std::optional<FluidTensorView<index, 2>>;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
+
+    BatchIterator(DataSampler& sampler, value_type&& val)
+        : mRef(&sampler), mVal(std::move(val))
+    {}
+
+    BatchIterator& operator++()
+    {
+      mVal = mRef->nextBatch();
+      return *this;
+    }
+    BatchIterator operator++(int)
+    {
+      BatchIterator res = *this;
+      ++(*this);
+      return res;
+    }
+    bool operator==(BatchIterator other) const
+    {
+      return mRef == other.mRef && (mVal == other.mVal);
+    }
+    bool operator!=(BatchIterator other) const { return !(*this == other); }
+
+    reference         operator*() { return mVal; }
+    value_type const& operator*() const { return mVal; }
+
+  private:
+    DataSampler* mRef;
+    value_type   mVal;
+  };
+
+  bool                  mShuffle;
+  index                 mTrainCount;  
+  std::random_device    mRnd;
+  std::mt19937          mGen{mRnd()};
+  std::vector<index>    mIdx;
+  index                 mBatchSize;
+  FluidTensor<index, 2> mBatch;
+  FluidTensor<index, 2> mValidation;
+  FluidTensor<index, 2> mTraining; // is there a way to avoid this?
+  index                 mBatchCount{0};
+
+  std::vector<index> makeIndex(index size, bool shuffle)
+  {
+    using std::begin, std::end;
+    std::vector<index> result(size);
+    std::iota(begin(result), end(result), 0);
+    if (shuffle) std::shuffle(begin(result), end(result), mGen);
+    return result;
+  }
+
+protected:
+  DataSampler(index size, index batchSize, double validationFraction,
+              bool shuffle)
+      : mShuffle{shuffle},
+        mTrainCount{
+            std::lrint((1 - std::clamp(validationFraction, 0.0, 1.0)) * size)},
+        mIdx(makeIndex(size, mShuffle)),
+        mBatchSize{std::min(mTrainCount, batchSize)},
+        mBatch(batchSize + (mTrainCount % mBatchSize), 2),
+        mValidation(size - mTrainCount, 2), mTraining(mTrainCount, 2)
+  {}
+public:
+  void reset()
+  {
+    using std::begin, std::end;
+
+    mBatchCount = 0;
+    if (mShuffle)
+      std::shuffle(begin(mIdx), begin(mIdx) + mTrainCount,
+                   mGen); // preserve validation set
+  }
+
+  // Returns in / out indices for this batch (not the data)
+  std::optional<FluidTensorView<index, 2>> nextBatch()
+  {
+    using std::begin, std::end, std::transform;
+
+    if (mBatchCount >= mTrainCount) return {};
+
+    index thisBatchSize = mBatchCount + mBatchSize < mTrainCount
+                              ? mBatchSize
+                              : mTrainCount - mBatchCount;
+
+    // if there's a remainder from n batches into the training data size,
+    // stick the extra on the first batch
+    if (index remainder = (mTrainCount % mBatchSize);
+        remainder && mBatchCount == 0)
+      thisBatchSize += remainder;
+
+    auto batchStart = mIdx.begin() + mBatchCount;
+    auto batchEnd = batchStart + thisBatchSize;
+    mBatchCount += thisBatchSize;
+
+    return derived().map(batchStart, batchEnd, mBatch)(Slice(0, thisBatchSize),
+                                                       Slice(0));
+  }
+
+  std::optional<FluidTensorView<index, 2>> validationSet()
+  {
+    if (mTrainCount == asSigned(mIdx.size())) return {}; // no validation
+
+    using std::begin, std::end;
+
+    auto validationStart = begin(mIdx) + mTrainCount;
+    auto validationEnd = end(mIdx);
+
+    return derived().map(validationStart, validationEnd, mValidation);
+  }
+
+  std::optional<FluidTensorView<index, 2>> trainingSet()
+  {
+    if (mTrainCount == 0) return {}; // no training data, which would be weird
+
+    using std::begin, std::end;
+
+    auto trainingStart = begin(mIdx);
+    auto trainingEnd = begin(mIdx) + mTrainCount;
+
+    return derived().map(trainingStart, trainingEnd, mTraining);
+  }
+
+
+  index batchSize() const { return mBatchSize; }
+
+  bool operator==(DataSampler const& other)
+  {
+    return &mIdx == &(other.mIdx) && mBatchCount == other.mBatchCount;
+  }
+
+  bool operator!=(DataSampler const& other) { return !(*this == other); }
+
+  BatchIterator begin()
+  {
+    reset();
+
+    auto b = nextBatch();
+
+    return BatchIterator(*this, std::move(b));
+  }
+
+  BatchIterator end()
+  {
+    return BatchIterator(*this, std::optional<FluidTensorView<index, 2>>{});
+  }
+
+private:
+  Derived& derived() { return *(static_cast<Derived*>(this)); }
+};
+} // namespace fluid::detail

--- a/tests/data/TestFluidDataSet.cpp
+++ b/tests/data/TestFluidDataSet.cpp
@@ -10,6 +10,7 @@
 #include <vector>
 #include <algorithm> 
 #include <string> 
+#include <random>
 
 using DataSet = fluid::FluidDataSet<std::string, int, 1>; 
 using fluid::FluidTensor; 

--- a/tests/data/TestFluidDataSet.cpp
+++ b/tests/data/TestFluidDataSet.cpp
@@ -179,5 +179,49 @@ TEST_CASE("FluidDataSet prints consistent summaries for approval","[FluidDataSet
 
         Approvals::verify(d.print()); 
     }
+}
 
+TEST_CASE("checkIDs works as expected")
+{
+  using fluid::index;
+  FluidTensor<index, 1> d(100);
+  std::iota(d.begin(), d.end(), 0);
+  using DS = fluid::FluidDataSet<index, index, 1>;
+
+  DS src(d, FluidTensorView<index, 2>(d).transpose());
+
+  SECTION("No False Postives")
+  {
+    DS   tgt(src);
+    auto missing = src.checkIDs(tgt);
+    CHECK(missing.size() == 0);
+  }
+
+  SECTION("Order insensitive")
+  {
+    std::vector<index> idx(100);
+    std::iota(idx.begin(), idx.end(), 0);
+    std::shuffle(idx.begin(), idx.end(), std::mt19937(std::random_device()()));
+    FluidTensor<index, 1> shuffled(100);
+    // shuffled <<= idx;
+    std::copy(idx.begin(), idx.end(), shuffled.begin());
+    DS   tgt(shuffled, FluidTensorView<index, 2>(shuffled).transpose());
+    auto missing = src.checkIDs(tgt);
+    CHECK(missing.size() == 0);
+    SECTION("Finds random deletions")
+    {
+      auto chop = shuffled(Slice(0, 50));
+      auto remain = shuffled(Slice(50, 50));
+
+      DS tgt_snip(remain, FluidTensorView<index, 2>(remain).transpose());
+
+      auto missing = src.checkIDs(tgt_snip);
+
+      std::vector<index> expected(50);
+      std::copy(chop.begin(), chop.end(), expected.begin());
+      std::sort(expected.begin(), expected.end());
+      std::sort(missing.begin(), missing.end());
+      CHECK_THAT(missing, Catch::Matchers::Equals(expected));
+    }
+  }
 }


### PR DESCRIPTION
fixes #292 

Ok, ok, I know this *looks* like a massive PR, but it's not really 😄 

### The problem
`SGD::train` assumes that its source and target data are *aligned*, i.e. that each index represents the same ID. This not necessarily the case because we're using unordered containers by design. You can make training silently fail to do anything sensible by adding points to source and target in a different order, for instance. This is baaaaad.

### But why is this diff so large, you 'orrible man? 
The core of this PR is decoupling the batching and sampling of data from `SGD`, a bit like pytorch. I like that `SGD` doesn't want to know about `DataSet`, it just needed to go further. 

So we have 
* some new classes that do data sampling: a base class, an implementation that properly matches source and target IDs, and a simple implementation for when data really are aligned (this opens up some cool future extensions*). 
* changes to SGD to remove its batching code and use this instead
* supporting changes to `FluidDataSet`, `FluidTensorView` 
* some tests 
* updates to MLP clients to actually check that IDs match and use appropriate sampler 

User-side, nothing much should change besides a couple of error messages: so, reviewers: please test this proposition by training against your own stuff and making sure it still works as it did. 

\* Like, it would now be pretty easy to enable quicker n' dirtier MLP training (resp. the rest of the data objects) with CCE buffers alone for those cases where people don't want / care about IDs. I think this would have significant workflow and teaching upsides...
