### PR TITLE
Fix missing template args caught by new clang

### DIFF
--- a/include/flucoma/clients/common/FluidBaseClient.hpp
+++ b/include/flucoma/clients/common/FluidBaseClient.hpp
@@ -213,7 +213,7 @@ public:
   template <size_t N, typename T>
   void set(T&& x, Result* reportage) noexcept
   {
-    mParams.template set(std::forward<T>(x), reportage);
+    mParams.template set<N>(std::forward<T>(x), reportage);
   }
 
   auto latency() const { return mClient.latency(); }

--- a/include/flucoma/clients/nrt/FluidSharedInstanceAdaptor.hpp
+++ b/include/flucoma/clients/nrt/FluidSharedInstanceAdaptor.hpp
@@ -169,7 +169,7 @@ public:
   typename ParamType<N>::type
   applyConstraintToMax(typename ParamType<N>::type x) const
   {
-    return mParams->template applyConstraintToMax(x);
+    return mParams->template applyConstraintToMax<N>(x);
   }
 
   template <template <size_t N, typename T> class Func, typename... Args>


### PR DESCRIPTION
@tremblap discovered that the most recent clang is newly upset by calls like `x.template f()`, i.e. where the template argument list is absent. We had two such, seemed like a resonable thing to complain about really. 