### PR TITLE
Fix/trigger output logic

### DIFF
--- a/include/flucoma/clients/nrt/KMeansClient.hpp
+++ b/include/flucoma/clients/nrt/KMeansClient.hpp
@@ -311,7 +311,7 @@ public:
   void process(std::vector<FluidTensorView<T, 1>>& input,
                std::vector<FluidTensorView<T, 1>>& output, FluidContext&)
   {
-    output[0] <<= input[0];
+    output[0](0) = 0;
     if (input[0](0) > 0)
     {
       auto kmeansPtr = get<kModel>().get().lock();
@@ -344,6 +344,7 @@ public:
       point <<= BufferAdaptor::ReadAccess(get<kInputBuffer>().get())
                   .samps(0, dims, 0);
       outSamps[0] = kmeansPtr->algorithm().vq(point);
+      output[0](0) = 1;
     }
   }
 

--- a/include/flucoma/clients/nrt/KNNClassifierClient.hpp
+++ b/include/flucoma/clients/nrt/KNNClassifierClient.hpp
@@ -240,7 +240,7 @@ public:
   void process(std::vector<FluidTensorView<T, 1>>& input,
                std::vector<FluidTensorView<T, 1>>& output, FluidContext& c)
   {
-    output[0] <<= input[0];
+    output[0](0) = 0;
     if (input[0](0) > 0)
     {
       auto knnPtr = get<kModel>().get().lock();
@@ -267,6 +267,7 @@ public:
       std::string const& result = classifier.predict(
           algorithm.tree, point, algorithm.labels, k, weight, c.allocator());
       outBuf.samps(0)[0] = static_cast<double>(knnPtr->encodeIndex(result));
+      output[0](0) = 1;
     }
   }
 

--- a/include/flucoma/clients/nrt/KNNRegressorClient.hpp
+++ b/include/flucoma/clients/nrt/KNNRegressorClient.hpp
@@ -240,7 +240,7 @@ public:
   void process(std::vector<FluidTensorView<T, 1>>& in,
                std::vector<FluidTensorView<T, 1>>& out, FluidContext& c)
   {
-    out[0] <<= in[0];
+    out[0](0) = 0;
     if (in[0](0) > 0)
     {
       auto knnPtr = get<kModel>().get().lock();
@@ -272,6 +272,7 @@ public:
       regressor.predict(algorithm.tree, algorithm.target, input, output, k,
                         weight, c.allocator());
       outBuf.samps(0) <<= output;
+      out[0](0) = 1;
     }
   }
 

--- a/include/flucoma/clients/nrt/KNNRegressorClient.hpp
+++ b/include/flucoma/clients/nrt/KNNRegressorClient.hpp
@@ -240,8 +240,8 @@ public:
   void process(std::vector<FluidTensorView<T, 1>>& input,
                std::vector<FluidTensorView<T, 1>>& output, FluidContext& c)
   {
-    out[0](0) = 0;
-    if (in[0](0) > 0)
+    output[0](0) = 0;
+    if (input[0](0) > 0)
     {
       auto knnPtr = get<kModel>().get().lock();
       if (!knnPtr)
@@ -271,8 +271,8 @@ public:
 
       regressor.predict(algorithm.tree, algorithm.target, in, out, k,
                         weight, c.allocator());
-      outBuf.samps(0) <<= output;
-      out[0](0) = 1;
+      outBuf.samps(0) <<= out;
+      output[0](0) = 1;
     }
   }
 

--- a/include/flucoma/clients/nrt/MLPClassifierClient.hpp
+++ b/include/flucoma/clients/nrt/MLPClassifierClient.hpp
@@ -320,7 +320,7 @@ public:
   void process(std::vector<FluidTensorView<T, 1>>& input,
                std::vector<FluidTensorView<T, 1>>& output, FluidContext&)
   {
-    output[0] <<= input[0];
+    output[0](0) = 0;
     if (input[0](0) > 0)
     {
       auto mlpPtr = get<kModel>().get().lock();
@@ -350,6 +350,7 @@ public:
       auto& label = algorithm.encoder.decodeOneHot(dest);
       outBuf.samps(0)[0] =
           static_cast<double>(algorithm.encoder.encodeIndex(label));
+      output[0](0) = 1;
     }
   }
 

--- a/include/flucoma/clients/nrt/MLPRegressorClient.hpp
+++ b/include/flucoma/clients/nrt/MLPRegressorClient.hpp
@@ -305,7 +305,7 @@ public:
   void process(std::vector<FluidTensorView<T, 1>>& input,
                std::vector<FluidTensorView<T, 1>>& output, FluidContext&)
   {
-    output[0] <<= input[0];
+    output[0](0) = 0;
     if (input[0](0) > 0)
     {
       auto MLPRef = get<kModel>().get().lock();
@@ -341,6 +341,7 @@ public:
                 .samps(0, inputSize, 0);
       algorithm.processFrame(src, dest, inputTap, outputTap);
       outBuf.samps(0, outputSize, 0) <<= dest;
+      output[0](0) = 1;
     }
   }
 

--- a/include/flucoma/clients/nrt/NormalizeClient.hpp
+++ b/include/flucoma/clients/nrt/NormalizeClient.hpp
@@ -214,7 +214,7 @@ public:
   void process(std::vector<FluidTensorView<T, 1>>& input,
                std::vector<FluidTensorView<T, 1>>& output, FluidContext&)
   {
-    output[0] <<= input[0];
+    output[0](0) = 0;
     if (input[0](0) > 0)
     {
       auto normPtr = get<kModel>().get().lock();
@@ -237,6 +237,7 @@ public:
                 .samps(0, algorithm.dims(), 0);
       algorithm.processFrame(src, dest, get<kInvert>() == 1);
       outBuf.samps(0, algorithm.dims(), 0) <<= dest;
+      output[0](0) = 1;
     }
   }
 

--- a/include/flucoma/clients/nrt/PCAClient.hpp
+++ b/include/flucoma/clients/nrt/PCAClient.hpp
@@ -241,7 +241,7 @@ public:
   void process(std::vector<FluidTensorView<T, 1>>& input,
                std::vector<FluidTensorView<T, 1>>& output, FluidContext& c)
   {
-    output[0] <<= input[0];
+    output[0](0) = 0;
     if (input[0](0) > 0)
     {
       auto PCAPtr = get<kModel>().get().lock();
@@ -266,6 +266,7 @@ public:
                   .samps(0, algorithm.dims(), 0);
       algorithm.processFrame(src, dest, k, get<kWhiten>() == 1);
       outBuf.samps(0, k, 0) <<= dest;
+      output[0](0) = 1;
     }
   }
 

--- a/include/flucoma/clients/nrt/RobustScaleClient.hpp
+++ b/include/flucoma/clients/nrt/RobustScaleClient.hpp
@@ -216,7 +216,7 @@ public:
   void process(std::vector<FluidTensorView<T, 1>>& input,
                std::vector<FluidTensorView<T, 1>>& output, FluidContext&)
   {
-    output[0] <<= input[0];
+    output[0](0) = 0;
     if (input[0](0) > 0)
     {
       auto robustPtr = get<kModel>().get().lock();
@@ -239,6 +239,7 @@ public:
                 .samps(0, algorithm.dims(), 0);
       algorithm.processFrame(src, dest, get<kInvert>() == 1);
       outBuf.samps(0, algorithm.dims(), 0) <<= dest;
+      output[0](0) = 1;
     }
   }
 

--- a/include/flucoma/clients/nrt/SKMeansClient.hpp
+++ b/include/flucoma/clients/nrt/SKMeansClient.hpp
@@ -320,7 +320,7 @@ public:
   void process(std::vector<FluidTensorView<T, 1>>& input,
                std::vector<FluidTensorView<T, 1>>& output, FluidContext&)
   {
-    output[0] = input[0];
+    output[0](0) = 0;
     if (input[0](0) > 0)
     {
       auto kmeansPtr = get<kModel>().get().lock();
@@ -342,6 +342,7 @@ public:
       point <<= BufferAdaptor::ReadAccess(get<kInputBuffer>().get())
                   .samps(0, dims, 0);
       outSamps[0] = kmeansPtr->algorithm().vq(point);
+      output[0](0) = 1;
     }
   }
 

--- a/include/flucoma/clients/nrt/StandardizeClient.hpp
+++ b/include/flucoma/clients/nrt/StandardizeClient.hpp
@@ -210,7 +210,7 @@ public:
   void process(std::vector<FluidTensorView<T, 1>>& input,
                std::vector<FluidTensorView<T, 1>>& output, FluidContext&)
   {
-    output[0] <<= input[0];
+    output[0](0) = 0;
     if (input[0](0) > 0)
     {
       auto stdPtr = get<kModel>().get().lock();
@@ -235,6 +235,7 @@ public:
                 .samps(0, algorithm.dims(), 0);
       algorithm.processFrame(src, dest, get<kInvert>() == 1);
       outBuf.samps(0, algorithm.dims(), 0) <<= dest;
+      output[0](0) = 1;
     }
   }
 

--- a/include/flucoma/clients/nrt/UMAPClient.hpp
+++ b/include/flucoma/clients/nrt/UMAPClient.hpp
@@ -207,7 +207,7 @@ public:
   void process(std::vector<FluidTensorView<T, 1>>& input,
                std::vector<FluidTensorView<T, 1>>& output, FluidContext&)
   {
-    output[0] <<= input[0];
+    output[0](0) = 0;
     if (input[0](0) > 0)
     {
       auto UMAPPtr = get<kModel>().get().lock();
@@ -233,6 +233,7 @@ public:
                 .samps(0, inSize, 0);
       algorithm.transformPoint(src, dest);
       outBuf.samps(0, outSize, 0) <<= dest;
+      output[0](0) = 1;
     }
   }
 


### PR DESCRIPTION
This fixes the logic of the trigger output of the KR objects.

Instead of copying the input to the output, we now output 0 except in the block where the kr action will have been successful. If the process function bails, it will give the user nothing, which is a good way to troubleshoot and in line with trigger chaining.