### PR TITLE
FluidDataSet: `point` args in `add` and `update` are now const

### DIFF
--- a/include/flucoma/data/FluidDataSet.hpp
+++ b/include/flucoma/data/FluidDataSet.hpp
@@ -104,7 +104,7 @@ bool add(idType const& id, FluidTensorView<const dataType, N> point)
       return pos->second;
   }
 
-  bool update(idType const& id, FluidTensorView<dataType, N> const point)
+bool update(idType const& id, FluidTensorView<const dataType, N> point)
   {
     auto pos = mIndex.find(id);
     if (pos == mIndex.end())


### PR DESCRIPTION
road tested on all UTs, fixes #80 