### PR TITLE
Update flucoma-core-ci.yml

### DIFF
--- a/.github/workflows/flucoma-core-ci.yml
+++ b/.github/workflows/flucoma-core-ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-latest, macOS-latest]
+        os: [ubuntu-22.04, windows-2022, macOS-latest]
       fail-fast: false 
       
     steps:  


### PR DESCRIPTION
Weird windows test fails correlated with switching CI to `windows-latest`, seeing if rolling back fixes this or if cause is something esle