### PR TITLE
loudness: fix crash-inducing min requirement for winsize

### DIFF
--- a/include/flucoma/clients/rt/LoudnessClient.hpp
+++ b/include/flucoma/clients/rt/LoudnessClient.hpp
@@ -37,7 +37,8 @@ constexpr auto LoudnessParams = defineParameters(
     ChoicesParam("select","Selection of Outputs","loudness","peak"),
     EnumParam("kWeighting", "Apply K-Weighting", 1, "Off", "On"),
     EnumParam("truePeak", "Compute True Peak", 1, "Off", "On"),
-    LongParam("windowSize", "Window Size", 1024, UpperLimit<kMaxWindowSize>()),
+    LongParam("windowSize", "Window Size", 1024, Min(1),
+              UpperLimit<kMaxWindowSize>()),
     LongParam("hopSize", "Hop Size", 512, Min(1)),
     LongParam<Fixed<true>>("maxWindowSize", "Max Window Size", 16384, Min(4),
                            PowerOfTwo{}, Max(32768)) // 17640 next power of two


### PR DESCRIPTION
it was crashing with 0 as winsize. now it doesn't