### PR TITLE
add 'containsId' method to containers

### DIFF
--- a/include/flucoma/clients/nrt/DataSetClient.hpp
+++ b/include/flucoma/clients/nrt/DataSetClient.hpp
@@ -229,6 +229,11 @@ public:
     return OK();
   }
 
+  MessageResult<double> containsId(string id) const
+  {
+    return mAlgorithm.contains(id) ? 1 : 0;
+  }
+
   MessageResult<FluidTensor<rt::string, 1>> kNearest(InputBufferPtr data,
                                                      index nNeighbours) const
   {
@@ -324,6 +329,7 @@ public:
         makeMessage("fromBuffer", &DataSetClient::fromBuffer),
         makeMessage("toBuffer", &DataSetClient::toBuffer),
         makeMessage("getIds", &DataSetClient::getIds),
+        makeMessage("containsId", &DataSetClient::containsId),
         makeMessage("kNearestDist", &DataSetClient::kNearestDist),
         makeMessage("kNearest", &DataSetClient::kNearest));
   }

--- a/include/flucoma/clients/nrt/LabelSetClient.hpp
+++ b/include/flucoma/clients/nrt/LabelSetClient.hpp
@@ -142,6 +142,11 @@ public:
     return OK();
   }
 
+  MessageResult<double> containsId(string id) const
+  {
+    return mAlgorithm.contains(id) ? 1 : 0;
+  }
+  
   MessageResult<string> print() 
   { 
     return "LabelSet " + std::string(get<kName>()) + ": " + mAlgorithm.print();
@@ -164,7 +169,8 @@ public:
         makeMessage("clear", &LabelSetClient::clear),
         makeMessage("write", &LabelSetClient::write),
         makeMessage("read", &LabelSetClient::read),
-        makeMessage("getIds", &LabelSetClient::getIds));
+        makeMessage("getIds", &LabelSetClient::getIds),
+        makeMessage("containsId", &LabelSetClient::containsId));
   }
 
   const LabelSet getLabelSet() const { return mAlgorithm; }

--- a/include/flucoma/data/FluidDataSet.hpp
+++ b/include/flucoma/data/FluidDataSet.hpp
@@ -104,7 +104,7 @@ bool add(idType const& id, FluidTensorView<const dataType, N> point)
       return pos->second;
   }
 
-bool update(idType const& id, FluidTensorView<const dataType, N> point)
+  bool update(idType const& id, FluidTensorView<const dataType, N> point)
   {
     auto pos = mIndex.find(id);
     if (pos == mIndex.end())
@@ -128,6 +128,11 @@ bool update(idType const& id, FluidTensorView<const dataType, N> point)
         if (point.second > current) point.second--;
     }
     return true;
+  }
+
+  bool contains(idType const& id) const
+  {
+    return (mIndex.count(id) == 1);
   }
 
   FluidTensorView<dataType, N + 1>       getData() { return mData; }


### PR DESCRIPTION
I needed that for stuff in SC, and now Balint needs it for something in Max... and I needed an easy way back in the codebase so I implemented it the way @weefuzzy suggested a few years ago.

It works. Comments/Questions for the boss:
- containsid (in max) is ugly but just 'contains' is ambiguous, especially for LabelSet.
- I need to do the docs and sc method and include in help of Max+Pd but before I do so, maybe we should see if my code is clean enough